### PR TITLE
Change `Option<&'config FieldConfig<N>>` to `*const FieldConfig<N>`

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -217,10 +217,22 @@ impl<'a, const N: usize> MulAssign<&'a Self> for RandomField<N> {
         }
 
         if self.is_one() {
-            *self = *rhs;
+            self.value = rhs.value;
+
+            // If we do have a config we don't care.
+            if self.has_no_config() && !rhs.has_no_config() {
+                self.config = rhs.config;
+            }
+
             return;
         }
+
         if rhs.is_one() {
+            // If we do have a config we don't care.
+            if self.has_no_config() && !rhs.has_no_config() {
+                self.config = rhs.config;
+            }
+
             return;
         }
 


### PR DESCRIPTION
The problem was implementing the `Hash` trait for the `RandomField`. Now it's easily derivable.

