### PR TITLE
Refactor CCS_F and SpartanProver to remove FieldConfig type parameter

### DIFF
--- a/benches/spartan_benches.rs
+++ b/benches/spartan_benches.rs
@@ -43,7 +43,7 @@ fn benchmark_spartan_prover<const I: usize, const N: usize>(
                 KeccakTranscript::new,
                 |mut prover_transcript| {
                     black_box(
-                        SpartanProver::<I, _, _, _>::prove(
+                        SpartanProver::<I, _>::prove(
                             &prover,
                             &statement_f,
                             &z_ccs,
@@ -89,7 +89,7 @@ fn benchmark_spartan_verifier<const I: usize, const N: usize>(
             )
             .expect("Failed to prepare for random field PIOP");
 
-        let (spartan_proof, _) = SpartanProver::<I, _, _, _>::prove(
+        let (spartan_proof, _) = SpartanProver::<I, _>::prove(
             &prover,
             &statement_f,
             &z_ccs,
@@ -105,7 +105,7 @@ fn benchmark_spartan_verifier<const I: usize, const N: usize>(
                 KeccakTranscript::new,
                 |mut verifier_transcript| {
                     black_box(
-                        SpartanVerifier::<RandomField<N>, ConfigRef<N>, FieldConfig<N>>::verify(
+                        SpartanVerifier::<RandomField<N>>::verify(
                             &verifier,
                             &spartan_proof,
                             &ccs_f,

--- a/src/ccs/ccs_z.rs
+++ b/src/ccs/ccs_z.rs
@@ -12,7 +12,7 @@ use super::{
 use crate::{
     ccs::error::CSError as Error,
     field::RandomField,
-    field_config::{ConfigRef, FieldConfig},
+    field_config::ConfigRef,
     sparse_matrix::{dense_matrix_to_sparse, SparseMatrix},
     traits::FieldMap,
 };
@@ -133,7 +133,7 @@ impl<const I: usize> CCS_Z<I> {
 
 impl<'cfg, const I: usize, const N: usize> FieldMap<ConfigRef<'cfg, N>> for CCS_Z<I> {
     type Cfg = ConfigRef<'cfg, N>;
-    type Output = CCS_F<RandomField<'cfg, N>, FieldConfig<N>>;
+    type Output = CCS_F<RandomField<'cfg, N>>;
 
     fn map_to_field(&self, config: Self::Cfg) -> Self::Output {
         match config.pointer() {

--- a/src/ccs/test_utils.rs
+++ b/src/ccs/test_utils.rs
@@ -8,10 +8,7 @@ use super::{
     ccs_z::{Statement_Z, Witness_Z, CCS_Z},
 };
 use crate::{
-    field::RandomField,
-    field_config::{ConfigRef, FieldConfig},
-    sparse_matrix::SparseMatrix,
-    traits::FieldMap,
+    field::RandomField, field_config::ConfigRef, sparse_matrix::SparseMatrix, traits::FieldMap,
 };
 
 pub(crate) fn create_dummy_identity_sparse_matrix_Z<const N: usize>(
@@ -127,7 +124,7 @@ fn get_dummy_ccs_F_from_z<'cfg, const N: usize>(
     pub_io_len: usize,
     config: ConfigRef<'cfg, N>,
 ) -> (
-    CCS_F<RandomField<'cfg, N>, FieldConfig<N>>,
+    CCS_F<RandomField<'cfg, N>>,
     Statement_F<RandomField<'cfg, N>>,
     Witness_F<RandomField<'cfg, N>>,
 ) {
@@ -182,7 +179,7 @@ pub fn get_dummy_ccs_F_from_z_length<'cfg, const N: usize>(
     config: ConfigRef<'cfg, N>,
 ) -> (
     Vec<RandomField<'cfg, N>>,
-    CCS_F<RandomField<'cfg, N>, FieldConfig<N>>,
+    CCS_F<RandomField<'cfg, N>>,
     Statement_F<RandomField<'cfg, N>>,
     Witness_F<RandomField<'cfg, N>>,
 ) {

--- a/src/traits/types.rs
+++ b/src/traits/types.rs
@@ -1,4 +1,9 @@
-pub trait Field {
+use ark_std::ops::Mul;
+use num_traits::{One, Zero};
+
+pub trait Field:
+    Zero + One + Clone + Copy + Default + Sync + Send + for<'a> Mul<&'a Self, Output = Self>
+{
     type I: Integer;
     type C: Config<Self::I>;
     type Cr: ConfigReference<Self::I, Self::C>;

--- a/src/zinc/tests.rs
+++ b/src/zinc/tests.rs
@@ -36,7 +36,7 @@ fn test_dummy_spartan_prover() {
         ZincProver::<I, N, ZipSpec1>::prepare_for_random_field_piop(&statement, &wit, &ccs, config)
             .expect("Failed to prepare for random field PIOP");
 
-    let proof = SpartanProver::<I, RandomField<N>, ConfigRef<N>, FieldConfig<N>>::prove(
+    let proof = SpartanProver::<I, RandomField<N>>::prove(
         &prover,
         &statement_f,
         &z_ccs,
@@ -69,17 +69,16 @@ fn test_spartan_verifier() {
         ZincProver::<I, N, ZipSpec1>::prepare_for_random_field_piop(&statement, &wit, &ccs, config)
             .expect("Failed to prepare for random field PIOP");
 
-    let (spartan_proof, _) =
-        SpartanProver::<I, RandomField<N>, ConfigRef<N>, FieldConfig<N>>::prove(
-            &prover,
-            &statement_f,
-            &z_ccs,
-            &z_mle,
-            &ccs_f,
-            &mut prover_transcript,
-            config,
-        )
-        .expect("Failed to generate Spartan proof");
+    let (spartan_proof, _) = SpartanProver::<I, RandomField<N>>::prove(
+        &prover,
+        &statement_f,
+        &z_ccs,
+        &z_mle,
+        &ccs_f,
+        &mut prover_transcript,
+        config,
+    )
+    .expect("Failed to generate Spartan proof");
 
     let verifier = ZincVerifier::<I, N, _> {
         data: ark_std::marker::PhantomData::<ZipSpec1>,
@@ -88,7 +87,7 @@ fn test_spartan_verifier() {
 
     config.reference().expect("Field config cannot be none");
 
-    let res = SpartanVerifier::<RandomField<N>, ConfigRef<N>, FieldConfig<N>>::verify(
+    let res = SpartanVerifier::<RandomField<N>>::verify(
         &verifier,
         &spartan_proof,
         &ccs_f,
@@ -119,24 +118,23 @@ fn test_dummy_spartan_verifier() {
         ZincProver::<I, N, ZipSpec1>::prepare_for_random_field_piop(&statement, &wit, &ccs, config)
             .expect("Failed to prepare for random field PIOP");
 
-    let (spartan_proof, _) =
-        SpartanProver::<I, RandomField<N>, ConfigRef<N>, FieldConfig<N>>::prove(
-            &prover,
-            &statement_f,
-            &z_ccs,
-            &z_mle,
-            &ccs_f,
-            &mut prover_transcript,
-            config,
-        )
-        .expect("Failed to generate Spartan proof");
+    let (spartan_proof, _) = SpartanProver::<I, RandomField<N>>::prove(
+        &prover,
+        &statement_f,
+        &z_ccs,
+        &z_mle,
+        &ccs_f,
+        &mut prover_transcript,
+        config,
+    )
+    .expect("Failed to generate Spartan proof");
 
     let verifier = ZincVerifier::<I, N, _> {
         data: ark_std::marker::PhantomData::<ZipSpec1>,
     };
     let mut verifier_transcript = KeccakTranscript::new();
     config.reference().expect("Field config cannot be none");
-    let res = SpartanVerifier::<RandomField<N>, ConfigRef<N>, FieldConfig<N>>::verify(
+    let res = SpartanVerifier::<RandomField<N>>::verify(
         &verifier,
         &spartan_proof,
         &ccs_f,
@@ -169,17 +167,16 @@ fn test_failing_spartan_verifier() {
         ZincProver::<I, N, ZipSpec1>::prepare_for_random_field_piop(&statement, &wit, &ccs, config)
             .expect("Failed to prepare for random field PIOP");
 
-    let (spartan_proof, _) =
-        SpartanProver::<I, RandomField<N>, ConfigRef<N>, FieldConfig<N>>::prove(
-            &prover,
-            &statement_f,
-            &z_ccs,
-            &z_mle,
-            &ccs_f,
-            &mut prover_transcript,
-            config,
-        )
-        .expect("Failed to generate Spartan proof");
+    let (spartan_proof, _) = SpartanProver::<I, RandomField<N>>::prove(
+        &prover,
+        &statement_f,
+        &z_ccs,
+        &z_mle,
+        &ccs_f,
+        &mut prover_transcript,
+        config,
+    )
+    .expect("Failed to generate Spartan proof");
 
     let verifier = ZincVerifier::<I, N, _> {
         data: ark_std::marker::PhantomData::<ZipSpec1>,
@@ -187,7 +184,7 @@ fn test_failing_spartan_verifier() {
     let mut verifier_transcript = KeccakTranscript::new();
 
     config.reference().expect("Field config cannot be none");
-    let res = SpartanVerifier::<RandomField<N>, ConfigRef<N>, FieldConfig<N>>::verify(
+    let res = SpartanVerifier::<RandomField<N>>::verify(
         &verifier,
         &spartan_proof,
         &ccs_f,

--- a/src/zinc/utils.rs
+++ b/src/zinc/utils.rs
@@ -85,7 +85,7 @@ pub fn prepare_lin_sumcheck_polynomial<'cfg, const N: usize>(
 
 pub(crate) fn sumcheck_polynomial_comb_fn_1<'cfg, const N: usize>(
     vals: &[RandomField<'cfg, N>],
-    ccs: &CCS_F<RandomField<'cfg, N>, FieldConfig<N>>,
+    ccs: &CCS_F<RandomField<'cfg, N>>,
 ) -> RandomField<'cfg, N> {
     let mut result = RandomField::zero();
     'outer: for (i, &c) in ccs.c.iter().enumerate() {


### PR DESCRIPTION
- Refactor SpartanProver and SpartanVerifer to use Field as parameter 
- Implement SpartanProver and SpartanVerifier for RandomField.