### PR TITLE
Refactor Statement_F and related types to use Field

### DIFF
--- a/src/ccs/ccs_z.rs
+++ b/src/ccs/ccs_z.rs
@@ -14,7 +14,7 @@ use crate::{
     field::RandomField,
     field_config::ConfigRef,
     sparse_matrix::{dense_matrix_to_sparse, SparseMatrix},
-    traits::FieldMap,
+    traits::{ConfigReference, FieldMap},
 };
 
 ///  * `R: Ring` - the ring algebra over which the constraint system operates

--- a/src/ccs/test_utils.rs
+++ b/src/ccs/test_utils.rs
@@ -8,7 +8,10 @@ use super::{
     ccs_z::{Statement_Z, Witness_Z, CCS_Z},
 };
 use crate::{
-    field::RandomField, field_config::ConfigRef, sparse_matrix::SparseMatrix, traits::FieldMap,
+    field::RandomField,
+    field_config::ConfigRef,
+    sparse_matrix::SparseMatrix,
+    traits::{ConfigReference, FieldMap},
 };
 
 pub(crate) fn create_dummy_identity_sparse_matrix_Z<const N: usize>(

--- a/src/field_config.rs
+++ b/src/field_config.rs
@@ -282,6 +282,14 @@ impl<'cfg, const N: usize> ConfigReference<Words<N>, BigInt<N>, FieldConfig<N>>
     fn reference(&self) -> Option<&'cfg FieldConfig<N>> {
         self.0
     }
+
+    unsafe fn new(config_ptr: *mut FieldConfig<N>) -> Self {
+        Self(Option::from(config_ptr.as_ref().unwrap()))
+    }
+
+    fn pointer(&self) -> Option<*mut FieldConfig<N>> {
+        self.0.map(|p| p as *const _ as *mut _)
+    }
 }
 
 impl<const N: usize> PartialEq for ConfigRef<'_, N> {
@@ -300,15 +308,6 @@ unsafe impl<const N: usize> Sync for ConfigRef<'_, N> {}
 unsafe impl<const N: usize> Send for ConfigRef<'_, N> {}
 
 impl<const N: usize> ConfigRef<'_, N> {
-    pub fn pointer(&self) -> Option<*mut FieldConfig<N>> {
-        self.0.map(|p| p as *const _ as *mut _)
-    }
-
-    #[allow(clippy::missing_safety_doc)] // TODO Should be documented.
-    pub unsafe fn new(config_ptr: *mut FieldConfig<N>) -> Self {
-        Self(Option::from(config_ptr.as_ref().unwrap()))
-    }
-
     pub const NONE: Self = Self(None);
 }
 

--- a/src/sparse_matrix.rs
+++ b/src/sparse_matrix.rs
@@ -5,7 +5,10 @@ use ark_std::{rand::Rng, vec, vec::Vec};
 use crypto_bigint::Random;
 
 use crate::{
-    field::RandomField, field_config::ConfigRef, poly::alloc::string::ToString, traits::FieldMap,
+    field::RandomField,
+    field_config::ConfigRef,
+    poly::alloc::string::ToString,
+    traits::{Field, FieldMap},
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -165,13 +168,13 @@ where
     r
 }
 
-pub fn compute_eval_table_sparse<'cfg, const N: usize>(
-    M: &SparseMatrix<RandomField<'cfg, N>>,
-    rx: &[RandomField<'cfg, N>],
+pub fn compute_eval_table_sparse<F: Field>(
+    M: &SparseMatrix<F>,
+    rx: &[F],
     num_rows: usize,
     num_cols: usize,
-    config: ConfigRef<'cfg, N>,
-) -> Vec<RandomField<'cfg, N>> {
+    config: F::Cr,
+) -> Vec<F> {
     assert_eq!(rx.len(), num_rows);
     M.coeffs.iter().enumerate().fold(
         vec![0u32.map_to_field(config); num_cols],

--- a/src/sumcheck/prover.rs
+++ b/src/sumcheck/prover.rs
@@ -14,7 +14,7 @@ use crate::{
     field::RandomField,
     field_config::ConfigRef,
     poly_f::mle::{DenseMultilinearExtension, MultilinearExtension},
-    traits::FieldMap,
+    traits::{ConfigReference, FieldMap},
 };
 
 /// Prover Message

--- a/src/traits/types.rs
+++ b/src/traits/types.rs
@@ -1,6 +1,7 @@
 use ark_std::{
     fmt::Debug,
-    ops::{Index, IndexMut, Mul, Neg, Range, RangeTo, RemAssign},
+    ops::{AddAssign, Index, IndexMut, Mul, Neg, Range, RangeTo, RemAssign},
+    UniformRand,
 };
 use crypto_bigint::NonZero;
 use num_traits::{One, Zero};
@@ -18,6 +19,8 @@ pub trait Field:
     + for<'a> Mul<&'a Self, Output = Self>
     + Neg<Output = Self>
     + Debug
+    + for<'a> AddAssign<&'a Self>
+    + UniformRand
 {
     type I: Integer<Self::W> + From<Self::CryptoInt>;
     type C: Config<Self::W, Self::I>;
@@ -40,6 +43,11 @@ pub trait Config<W: Words, I: Integer<W>> {
 }
 pub trait ConfigReference<W: Words, I: Integer<W>, C: Config<W, I>>: Copy + Clone {
     fn reference(&self) -> Option<&C>;
+
+    #[allow(clippy::missing_safety_doc)] // TODO Should be documented.
+    unsafe fn new(config_ptr: *mut C) -> Self;
+
+    fn pointer(&self) -> Option<*mut C>;
 }
 
 pub trait Words:

--- a/src/zinc/prover.rs
+++ b/src/zinc/prover.rs
@@ -21,7 +21,7 @@ use crate::{
     poly_z::mle::DenseMultilinearExtension as DenseMultilinearExtensionZ,
     sparse_matrix::SparseMatrix,
     sumcheck::{utils::build_eq_x_r, MLSumcheck, SumcheckProof},
-    traits::{Field, FieldMap},
+    traits::{ConfigReference, Field, FieldMap},
     transcript::KeccakTranscript,
     zip::{code::ZipSpec, pcs::structs::MultilinearZip, pcs_transcript::PcsTranscript},
 };


### PR DESCRIPTION
…d type for improved flexibility

- Refactor to_F_matrix function to use generic Field type for improved flexibility 
- Refactor Instance_F trait to use generic Field type for improved type safety 
- Refactor Witness_F to use generic Field type and clean up imports 
- Refactor Statement_F and compute_eval_table_sparse to use generic Field type