### PR TITLE
Modify encoding element to return 0 or 1

### DIFF
--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -169,7 +169,10 @@ impl KeccakTranscript {
 }
 impl<const L: usize> ZipTranscript<L> for KeccakTranscript {
     fn get_encoding_element(&mut self) -> Int<L> {
-        self.get_integer_challenge::<L>()
+        let byte = self.get_random_bytes(1)[0];
+        // cancels all bits and depends only on whether the random byte LSB is 0 or 1
+        let bit = byte & 1;
+        Int::<L>::from(bit as i8)
     }
 
     fn sample_unique_columns(


### PR DESCRIPTION
Modify encoding element to get either 0 or 1 based on a 50-50 probability. 
Steps in the code:

1. We get a random byte
2. We perform bitwise AND with 1, which turns all bits to 0 except the LSB which if is 0 returns 0 if its 1 returns 1.