### PR TITLE
Refactor ZincProver and ZincVerifier to use CryptoInt trait

### DIFF
--- a/examples/simple_r1cs.rs
+++ b/examples/simple_r1cs.rs
@@ -15,7 +15,7 @@ fn main() {
     let mut prover_transcript = KeccakTranscript::new();
 
     let (ccs, statement, witness) = get_ccs_stuff(3);
-    let field_config = draw_random_field::<INT_LIMBS, RandomField<FIELD_LIMBS>>(
+    let field_config = draw_random_field::<Int<INT_LIMBS>, RandomField<FIELD_LIMBS>>(
         &statement.public_input,
         &mut prover_transcript,
     );
@@ -23,7 +23,7 @@ fn main() {
     let config_ref = ConfigRef::from(&field_config);
 
     let proof = prover
-        .prove(
+        .prove::<Int<{ INT_LIMBS * 2 }>, Int<{ INT_LIMBS * 4 }>, Int<{ INT_LIMBS * 8 }>>(
             &statement,
             &witness,
             &mut prover_transcript,
@@ -37,7 +37,7 @@ fn main() {
 
     let mut verifier_transcript = KeccakTranscript::new();
     verifier
-        .verify(
+        .verify::<Int<{ INT_LIMBS * 2 }>, Int<{ INT_LIMBS * 4 }>, Int<{ INT_LIMBS * 8 }>>(
             &statement,
             proof,
             &mut verifier_transcript,

--- a/src/traits/types.rs
+++ b/src/traits/types.rs
@@ -157,6 +157,7 @@ pub trait CryptoInt:
     + Send
     + Sync
     + Debug
+    + for<'a> From<&'a Self>
 {
     type W: Words;
     type Uint: CryptoUint<W = Self::W>;

--- a/src/zinc/prover.rs
+++ b/src/zinc/prover.rs
@@ -1,5 +1,4 @@
 use ark_std::{sync::atomic::Ordering, vec::Vec};
-use crypto_bigint::Int;
 
 use super::{
     errors::{MleEvaluationError, SpartanError, ZincError},
@@ -10,7 +9,6 @@ use super::{
     },
 };
 use crate::{
-    biginteger::BigInt,
     ccs::{
         ccs_f::{Statement_F, CCS_F},
         ccs_z::{Instance_Z, Statement_Z, Witness_Z, CCS_Z},
@@ -21,52 +19,62 @@ use crate::{
     sumcheck::{utils::build_eq_x_r, MLSumcheck, SumcheckProof},
     traits::{ConfigReference, CryptoInt, Field, FieldMap},
     transcript::KeccakTranscript,
-    zip::{code::ZipSpec, pcs::structs::MultilinearZip, pcs_transcript::PcsTranscript},
+    zip::{
+        code::ZipSpec,
+        pcs::{
+            structs::{MultilinearZip, ZipTranscript},
+            utils::ToBytes,
+        },
+        pcs_transcript::PcsTranscript,
+    },
 };
 
 pub type SpartanResult<T, F> = Result<T, SpartanError<F>>;
 pub type ZincResult<T, F> = Result<T, ZincError<F>>;
 
-pub trait Prover<const I: usize, F: Field> {
-    fn prove(
+pub trait Prover<I: CryptoInt, F: Field> {
+    fn prove<I2, I4, I8>(
         &self,
-        statement: &Statement_Z<Int<I>>,
-        wit: &Witness_Z<Int<I>>,
+        statement: &Statement_Z<I>,
+        wit: &Witness_Z<I>,
         transcript: &mut KeccakTranscript,
-        ccs: &CCS_Z<Int<I>>,
+        ccs: &CCS_Z<I>,
         config: F::Cr,
-    ) -> Result<ZincProof<Int<I>, F>, ZincError<F>>
+    ) -> Result<ZincProof<I, F>, ZincError<F>>
     where
-        [(); 2 * I]:,
-        [(); 4 * I]:,
-        [(); 8 * I]:;
+        I8: CryptoInt + for<'a> From<&'a I> + for<'a> From<&'a I2>,
+        I4: CryptoInt + for<'a> From<&'a I> + for<'a> From<&'a I2> + ToBytes,
+        I2: CryptoInt + for<'a> From<&'a I>,
+        KeccakTranscript: ZipTranscript<I2>;
 }
 
-impl<const I: usize, F: Field, S: ZipSpec> Prover<I, F> for ZincProver<Int<I>, F, S>
+impl<I: CryptoInt, F: Field, S: ZipSpec> Prover<I, F> for ZincProver<I, F, S>
 where
-    for<'a> Int<I>: From<&'a F::I>,
-    for<'a> F::CryptoInt: From<&'a BigInt<I>>, // TODO
-    F::I: From<Int<I>>,
+    for<'a> I: From<&'a F::I>,
+    for<'a> F::CryptoInt: From<&'a I::I>, // TODO
+    F::I: From<I>,
+    I: FieldMap<F, Output = F>,
 {
-    fn prove(
+    fn prove<I2, I4, I8>(
         &self,
-        statement: &Statement_Z<Int<I>>,
-        wit: &Witness_Z<Int<I>>,
+        statement: &Statement_Z<I>,
+        wit: &Witness_Z<I>,
         transcript: &mut KeccakTranscript,
-        ccs: &CCS_Z<Int<I>>,
+        ccs: &CCS_Z<I>,
         config: F::Cr,
-    ) -> ZincResult<ZincProof<Int<I>, F>, F>
+    ) -> ZincResult<ZincProof<I, F>, F>
     where
-        [(); 2 * I]:,
-        [(); 4 * I]:,
-        [(); 8 * I]:,
+        I8: CryptoInt + for<'a> From<&'a I> + for<'a> From<&'a I2>,
+        I4: CryptoInt + for<'a> From<&'a I> + for<'a> From<&'a I2> + ToBytes,
+        I2: CryptoInt + for<'a> From<&'a I>,
+        KeccakTranscript: ZipTranscript<I2>,
     {
         // TODO: Write functionality to let the verifier know that there are no denominators that can be divided by q(As an honest prover)
         let (z_ccs, z_mle, ccs_f, statement_f) =
             Self::prepare_for_random_field_piop(statement, wit, ccs, config)?;
 
         // Prove Spartan protocol over random field
-        let (spartan_proof, r_y) = SpartanProver::<Int<I>, F>::prove(
+        let (spartan_proof, r_y) = SpartanProver::<I, F>::prove(
             self,
             &statement_f,
             &z_ccs,
@@ -77,8 +85,9 @@ where
         )?;
 
         // Commit to z_mle and prove its evaluation at v
-        let zip_proof =
-            Self::commit_z_mle_and_prove_evaluation(&z_mle, &ccs_f, &r_y, transcript, config)?;
+        let zip_proof = Self::commit_z_mle_and_prove_evaluation::<I2, I4, I8>(
+            &z_mle, &ccs_f, &r_y, transcript, config,
+        )?;
 
         // Return proof
         Ok(ZincProof {
@@ -119,17 +128,18 @@ pub trait SpartanProver<I: CryptoInt, F: Field> {
     ) -> SpartanResult<(SpartanProof<F>, Vec<F>), F>;
 }
 
-impl<const I: usize, F: Field, S: ZipSpec> SpartanProver<Int<I>, F> for ZincProver<Int<I>, F, S>
+impl<I: CryptoInt, F: Field, S: ZipSpec> SpartanProver<I, F> for ZincProver<I, F, S>
 where
-    for<'a> Int<I>: From<&'a F::I>,
-    for<'a> F::CryptoInt: From<&'a BigInt<I>>, // TODO
-    F::I: From<Int<I>>,
+    for<'a> I: From<&'a F::I>,
+    for<'a> F::CryptoInt: From<&'a I::I>, // TODO
+    F::I: From<I>,
+    I: FieldMap<F, Output = F>,
 {
     fn prove(
         &self,
         statement_f: &Statement_F<F>,
         z_ccs: &[F],
-        z_mle: &DenseMultilinearExtensionZ<Int<I>>,
+        z_mle: &DenseMultilinearExtensionZ<I>,
         ccs_f: &CCS_F<F>,
         transcript: &mut KeccakTranscript,
         config: F::Cr,
@@ -159,23 +169,24 @@ where
     }
 }
 
-impl<const I: usize, F: Field, S: ZipSpec> ZincProver<Int<I>, F, S>
+impl<I: CryptoInt, F: Field, S: ZipSpec> ZincProver<I, F, S>
 where
-    for<'a> Int<I>: From<&'a F::I>,
-    for<'a> F::CryptoInt: From<&'a BigInt<I>>, // TODO
-    F::I: From<Int<I>>,
+    for<'a> I: From<&'a F::I>,
+    for<'a> F::CryptoInt: From<&'a I::I>, // TODO
+    F::I: From<I>,
+    I: FieldMap<F, Output = F>,
 {
     pub type DenseMleF = DenseMultilinearExtension<F>;
-    pub type DenseMleZ = DenseMultilinearExtensionZ<Int<I>>;
+    pub type DenseMleZ = DenseMultilinearExtensionZ<I>;
     pub type CcsF = CCS_F<F>;
 
     pub type StatementF = Statement_F<F>;
 
     #[allow(clippy::type_complexity)] // TODO refactor this out
     pub fn prepare_for_random_field_piop(
-        statement: &Statement_Z<Int<I>>,
-        wit: &Witness_Z<Int<I>>,
-        ccs: &CCS_Z<Int<I>>,
+        statement: &Statement_Z<I>,
+        wit: &Witness_Z<I>,
+        ccs: &CCS_Z<I>,
         config: F::Cr,
     ) -> SpartanResult<(Vec<F>, Self::DenseMleZ, Self::CcsF, Self::StatementF), F> {
         // z_ccs vector, i.e. concatenation x || 1 || w.
@@ -208,15 +219,15 @@ where
     }
 
     fn get_z_ccs_and_z_mle(
-        statement: &Statement_Z<Int<I>>,
-        wit: &Witness_Z<Int<I>>,
-        ccs: &CCS_Z<Int<I>>,
+        statement: &Statement_Z<I>,
+        wit: &Witness_Z<I>,
+        ccs: &CCS_Z<I>,
         config: F::Cr,
     ) -> (Vec<F>, Self::DenseMleZ) {
         let mut z_ccs = statement.get_z_vector(&wit.w_ccs);
 
         if z_ccs.len() <= ccs.m {
-            z_ccs.resize(ccs.m, Int::<I>::ZERO);
+            z_ccs.resize(ccs.m, I::ZERO);
         }
         let z_mle = DenseMultilinearExtensionZ::from_evaluations_slice(ccs.s_prime, &z_ccs);
 
@@ -290,42 +301,34 @@ where
         Self::generate_sumcheck_proof(transcript, sumcheck_2_mles, ccs.s, 2, comb_fn_2, config)
     }
 
-    fn commit_z_mle_and_prove_evaluation(
+    fn commit_z_mle_and_prove_evaluation<I2, I4, I8>(
         z_mle: &Self::DenseMleZ,
         ccs: &Self::CcsF,
         r_y: &[F],
         transcript: &mut KeccakTranscript,
         config: F::Cr,
-    ) -> SpartanResult<ZipProof<Int<I>, F>, F>
+    ) -> SpartanResult<ZipProof<I, F>, F>
     where
-        [(); 2 * I]:,
-        [(); 4 * I]:,
-        [(); 8 * I]:,
+        I8: CryptoInt + for<'a> From<&'a I2> + for<'a> From<&'a I>,
+        I4: CryptoInt + for<'a> From<&'a I2> + for<'a> From<&'a I> + ToBytes,
+        I2: CryptoInt + for<'a> From<&'a I>,
+        KeccakTranscript: ZipTranscript<I2>,
     {
-        let param =
-            MultilinearZip::<Int<I>, Int<{ 2 * I }>, Int<{ 4 * I }>, Int<{ 8 * I }>, S, _>::setup(
-                ccs.m, transcript,
-            );
-        let (z_data, z_comm) = MultilinearZip::<
-            Int<I>,
-            Int<{ 2 * I }>,
-            Int<{ 4 * I }>,
-            Int<{ 8 * I }>,
-            S,
-            KeccakTranscript,
-        >::commit::<F>(&param, z_mle)?;
+        let param = MultilinearZip::<I, I2, I4, I8, S, _>::setup(ccs.m, transcript);
+        let (z_data, z_comm) =
+            MultilinearZip::<I, I2, I4, I8, S, KeccakTranscript>::commit::<F>(&param, z_mle)?;
         let mut pcs_transcript = PcsTranscript::new();
         let v = z_mle.map_to_field(config).evaluate(r_y, config).ok_or(
             MleEvaluationError::IncorrectLength(r_y.len(), z_mle.num_vars),
         )?;
-        MultilinearZip::<
-            Int<I>,
-            Int<{ 2 * I }>,
-            Int<{ 4 * I }>,
-            Int<{ 8 * I }>,
-            S,
-            KeccakTranscript,
-        >::open(&param, z_mle, &z_data, r_y, config, &mut pcs_transcript)?;
+        MultilinearZip::<I, I2, I4, I8, S, KeccakTranscript>::open(
+            &param,
+            z_mle,
+            &z_data,
+            r_y,
+            config,
+            &mut pcs_transcript,
+        )?;
 
         let pcs_proof = pcs_transcript.into_proof();
         Ok(ZipProof {

--- a/src/zinc/utils.rs
+++ b/src/zinc/utils.rs
@@ -2,7 +2,6 @@
 
 use ark_std::vec::Vec;
 use bytemuck::cast_slice;
-use crypto_bigint::Int;
 
 use super::errors::{MleEvaluationError, SpartanError};
 use crate::{
@@ -11,7 +10,7 @@ use crate::{
     prime_gen::get_prime,
     sparse_matrix::SparseMatrix,
     sumcheck::utils::build_eq_x_r,
-    traits::{Config, Field},
+    traits::{Config, CryptoInt, Field},
     transcript::KeccakTranscript,
 };
 
@@ -159,8 +158,8 @@ where
         .collect::<Result<_, E>>()
 }
 
-pub fn draw_random_field<const I: usize, F: Field>(
-    public_inputs: &[Int<I>],
+pub fn draw_random_field<I: CryptoInt, F: Field>(
+    public_inputs: &[I],
     transcript: &mut KeccakTranscript,
 ) -> F::C {
     for input in public_inputs {

--- a/src/zinc/verifier.rs
+++ b/src/zinc/verifier.rs
@@ -1,5 +1,4 @@
 use ark_std::{boxed::Box, vec::Vec};
-use crypto_bigint::Int;
 
 use super::{
     errors::{MleEvaluationError, SpartanError, ZincError},
@@ -7,54 +6,62 @@ use super::{
     utils::{draw_random_field, SqueezeBeta, SqueezeGamma},
 };
 use crate::{
-    biginteger::BigInt,
     ccs::{
         ccs_f::{Statement_F, CCS_F},
         ccs_z::{Statement_Z, CCS_Z},
     },
     poly_f::mle::DenseMultilinearExtension,
     sumcheck::{utils::eq_eval, MLSumcheck, SumCheckError::SumCheckFailed, SumcheckProof},
-    traits::{ConfigReference, Field, FieldMap},
+    traits::{ConfigReference, CryptoInt, Field, FieldMap},
     transcript::KeccakTranscript,
-    zip::{code::ZipSpec, pcs::structs::MultilinearZip, pcs_transcript::PcsTranscript},
+    zip::{
+        code::ZipSpec,
+        pcs::{
+            structs::{MultilinearZip, ZipTranscript},
+            utils::ToBytes,
+        },
+        pcs_transcript::PcsTranscript,
+    },
 };
 
-pub trait Verifier<const I: usize, F: Field> {
-    fn verify(
+pub trait Verifier<I: CryptoInt, F: Field> {
+    fn verify<I2, I4, I8>(
         &self,
-        cm_i: &Statement_Z<Int<I>>,
-        proof: ZincProof<Int<I>, F>,
+        cm_i: &Statement_Z<I>,
+        proof: ZincProof<I, F>,
         transcript: &mut KeccakTranscript,
-        ccs: &CCS_Z<Int<I>>,
+        ccs: &CCS_Z<I>,
         config: F::Cr,
     ) -> Result<(), ZincError<F>>
     where
-        [(); 2 * I]:,
-        [(); 4 * I]:,
-        [(); 8 * I]:;
+        I2: CryptoInt + FieldMap<F, Output = F> + for<'a> From<&'a I>,
+        I4: CryptoInt + FieldMap<F, Output = F> + ToBytes,
+        I8: CryptoInt + for<'a> From<&'a I2> + for<'a> From<&'a I> + for<'a> From<&'a I4>,
+        KeccakTranscript: ZipTranscript<I2>;
 }
 
 // TODO
-impl<const I: usize, F: Field, S: ZipSpec> Verifier<I, F> for ZincVerifier<Int<I>, F, S>
+impl<I: CryptoInt, F: Field, S: ZipSpec> Verifier<I, F> for ZincVerifier<I, F, S>
 where
-    Int<{ 2 * I }>: FieldMap<F, Output = F>,
-    Int<{ 4 * I }>: FieldMap<F, Output = F>,
-    for<'a> Int<I>: From<&'a F::I>,
-    F::I: From<Int<I>>,
-    for<'a> F::CryptoInt: From<&'a BigInt<I>>,
+    for<'a> I: From<&'a F::I>,
+    F::I: From<I>,
+    for<'a> F::CryptoInt: From<&'a I::I>,
+    I: FieldMap<F, Output = F>,
+    Self: SpartanVerifier<F>,
 {
-    fn verify(
+    fn verify<I2, I4, I8>(
         &self,
-        statement: &Statement_Z<Int<I>>,
-        proof: ZincProof<Int<I>, F>,
+        statement: &Statement_Z<I>,
+        proof: ZincProof<I, F>,
         transcript: &mut KeccakTranscript,
-        ccs: &CCS_Z<Int<I>>,
+        ccs: &CCS_Z<I>,
         config: F::Cr,
     ) -> Result<(), ZincError<F>>
     where
-        [(); 2 * I]:,
-        [(); 4 * I]:,
-        [(); 8 * I]:,
+        I2: CryptoInt + FieldMap<F, Output = F> + for<'a> From<&'a I>,
+        I4: CryptoInt + FieldMap<F, Output = F> + ToBytes,
+        I8: CryptoInt + for<'a> From<&'a I2> + for<'a> From<&'a I> + for<'a> From<&'a I4>,
+        KeccakTranscript: ZipTranscript<I2>,
     {
         if draw_random_field::<I, F>(&statement.public_input, transcript)
             != *config.reference().unwrap()
@@ -69,7 +76,7 @@ where
             SpartanVerifier::<F>::verify(self, &proof.spartan_proof, &ccs_F, transcript, config)
                 .map_err(ZincError::SpartanError)?;
 
-        self.verify_pcs_proof(
+        self.verify_pcs_proof::<I2, I4, I8>(
             &statement_f,
             &proof.zip_proof,
             &verification_points,
@@ -107,7 +114,7 @@ pub trait SpartanVerifier<F: Field> {
     ) -> Result<VerificationPoints<F>, SpartanError<F>>;
 }
 
-impl<const I: usize, F: Field, S: ZipSpec> SpartanVerifier<F> for ZincVerifier<Int<I>, F, S> {
+impl<I: CryptoInt, F: Field, S: ZipSpec> SpartanVerifier<F> for ZincVerifier<I, F, S> {
     fn verify(
         &self,
         proof: &SpartanProof<F>,
@@ -144,7 +151,7 @@ impl<const I: usize, F: Field, S: ZipSpec> SpartanVerifier<F> for ZincVerifier<I
     }
 }
 
-impl<const I: usize, F: Field, S: ZipSpec> ZincVerifier<Int<I>, F, S> {
+impl<I: CryptoInt, F: Field, S: ZipSpec> ZincVerifier<I, F, S> {
     fn verify_linearization_proof(
         &self,
         proof: &SumcheckProof<F>,
@@ -224,41 +231,26 @@ impl<const I: usize, F: Field, S: ZipSpec> ZincVerifier<Int<I>, F, S> {
         res
     }
 
-    fn verify_pcs_proof(
+    fn verify_pcs_proof<I2, I4, I8>(
         &self,
         cm_i: &Statement_F<F>,
-        zip_proof: &ZipProof<Int<I>, F>,
+        zip_proof: &ZipProof<I, F>,
         verification_points: &VerificationPoints<F>,
         ccs: &CCS_F<F>,
         transcript: &mut KeccakTranscript,
         config: F::Cr,
     ) -> Result<(), SpartanError<F>>
     where
-        [(); 2 * I]:,
-        [(); 4 * I]:,
-        [(); 8 * I]:,
-        Int<{ 2 * I }>: FieldMap<F, Output = F>,
-        Int<{ 4 * I }>: FieldMap<F, Output = F>,
+        I2: CryptoInt + FieldMap<F, Output = F> + for<'a> From<&'a I>,
+        I4: CryptoInt + FieldMap<F, Output = F> + ToBytes,
+        I8: CryptoInt + for<'a> From<&'a I2> + for<'a> From<&'a I> + for<'a> From<&'a I4>,
+        KeccakTranscript: ZipTranscript<I2>,
     {
-        let param = MultilinearZip::<
-            Int<I>,
-            Int<{ 2 * I }>,
-            Int<{ 4 * I }>,
-            Int<{ 8 * I }>,
-            S,
-            KeccakTranscript,
-        >::setup(ccs.m, transcript);
+        let param = MultilinearZip::<I, I2, I4, I8, S, KeccakTranscript>::setup(ccs.m, transcript);
         let mut pcs_transcript = PcsTranscript::from_proof(&zip_proof.pcs_proof);
         let r_y = &verification_points.rx_ry[ccs.s..];
 
-        MultilinearZip::<
-            Int<I>,
-            Int<{ 2 * I }>,
-            Int<{ 4 * I }>,
-            Int<{ 8 * I }>,
-            S,
-            KeccakTranscript,
-        >::verify(
+        MultilinearZip::<I, I2, I4, I8, S, KeccakTranscript>::verify(
             &param,
             &zip_proof.z_comm,
             r_y,


### PR DESCRIPTION
This change requires more verbose use of generic parameters, but it should be resolved in future commits