### PR TITLE
Rename types and traits for simpler use

### DIFF
--- a/benches/spartan_benches.rs
+++ b/benches/spartan_benches.rs
@@ -3,7 +3,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use zinc::{
     biginteger::BigInt,
     ccs::test_utils::get_dummy_ccs_Z_from_z_length,
-    crypto_int::CryptoInt,
+    crypto_int::Int,
     field::RandomField,
     field_config::{ConfigRef, FieldConfig},
     traits::{Config, ConfigReference},
@@ -24,7 +24,7 @@ fn benchmark_spartan_prover<const I: usize, const N: usize>(
     let mut group = c.benchmark_group(format!("spartan_prover for {} prime", prime));
     let mut rng = ark_std::test_rng();
 
-    let prover = ZincProver::<CryptoInt<I>, RandomField<N>, ZipSpec1> {
+    let prover = ZincProver::<Int<I>, RandomField<N>, ZipSpec1> {
         // If we are keeping primes around 128 bits we should stay with N = 3 hardcoded
         data: PhantomData,
     };
@@ -34,7 +34,7 @@ fn benchmark_spartan_prover<const I: usize, const N: usize>(
         let (_, ccs, statement, wit) = get_dummy_ccs_Z_from_z_length(n, &mut rng);
 
         let (z_ccs, z_mle, ccs_f, statement_f) =
-            ZincProver::<CryptoInt<I>, RandomField<N>, ZipSpec1>::prepare_for_random_field_piop(
+            ZincProver::<Int<I>, RandomField<N>, ZipSpec1>::prepare_for_random_field_piop(
                 &statement, &wit, &ccs, config,
             )
             .expect("Failed to prepare for random field PIOP");
@@ -44,7 +44,7 @@ fn benchmark_spartan_prover<const I: usize, const N: usize>(
                 KeccakTranscript::new,
                 |mut prover_transcript| {
                     black_box(
-                        SpartanProver::<CryptoInt<I>, _>::prove(
+                        SpartanProver::<Int<I>, _>::prove(
                             &prover,
                             &statement_f,
                             &z_ccs,
@@ -71,9 +71,9 @@ fn benchmark_spartan_verifier<const I: usize, const N: usize>(
     let mut group = c.benchmark_group(format!("spartan_verifier for {} prime", prime));
     let mut rng = ark_std::test_rng();
 
-    let prover = ZincProver::<CryptoInt<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
+    let prover = ZincProver::<Int<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
 
-    let verifier = ZincVerifier::<CryptoInt<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
+    let verifier = ZincVerifier::<Int<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
 
     for size in [12, 13, 14, 15, 16] {
         let n = 1 << size;
@@ -81,12 +81,12 @@ fn benchmark_spartan_verifier<const I: usize, const N: usize>(
         let mut prover_transcript = KeccakTranscript::new();
 
         let (z_ccs, z_mle, ccs_f, statement_f) =
-            ZincProver::<CryptoInt<I>, RandomField<N>, ZipSpec1>::prepare_for_random_field_piop(
+            ZincProver::<Int<I>, RandomField<N>, ZipSpec1>::prepare_for_random_field_piop(
                 &statement, &wit, &ccs, config,
             )
             .expect("Failed to prepare for random field PIOP");
 
-        let (spartan_proof, _) = SpartanProver::<CryptoInt<I>, _>::prove(
+        let (spartan_proof, _) = SpartanProver::<Int<I>, _>::prove(
             &prover,
             &statement_f,
             &z_ccs,

--- a/benches/zip_benches.rs
+++ b/benches/zip_benches.rs
@@ -13,7 +13,7 @@ use crypto_bigint::Random;
 use itertools::Itertools;
 use zinc::{
     biginteger::BigInt,
-    crypto_int::CryptoInt,
+    crypto_int::Int,
     field::RandomField,
     field_config::{ConfigRef, FieldConfig},
     poly_z::mle::{DenseMultilinearExtension, MultilinearExtension},
@@ -29,10 +29,10 @@ use zinc::{
 const INT_LIMBS: usize = 1;
 const FIELD_LIMBS: usize = 4;
 type BenchZip = MultilinearZip<
-    CryptoInt<INT_LIMBS>,
-    CryptoInt<{ 2 * INT_LIMBS }>,
-    CryptoInt<{ 4 * INT_LIMBS }>,
-    CryptoInt<{ 8 * INT_LIMBS }>,
+    Int<INT_LIMBS>,
+    Int<{ 2 * INT_LIMBS }>,
+    Int<{ 4 * INT_LIMBS }>,
+    Int<{ 8 * INT_LIMBS }>,
     ZipSpec1,
     KeccakTranscript,
 >;
@@ -47,8 +47,8 @@ fn encode_rows<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize
 
             let poly = DenseMultilinearExtension::rand(P, &mut rng);
 
-            let row_len = <Zip<CryptoInt<INT_LIMBS>, CryptoInt<{2*INT_LIMBS}>> as LinearCodes<CryptoInt<INT_LIMBS>, CryptoInt<{8*INT_LIMBS}>>>::row_len(params.zip());
-            let codeword_len = <Zip<CryptoInt<INT_LIMBS>, CryptoInt<{2*INT_LIMBS}>> as LinearCodes<CryptoInt<INT_LIMBS>, CryptoInt<{8*INT_LIMBS}>>>::codeword_len(params.zip());
+            let row_len = <Zip<Int<INT_LIMBS>, Int<{2*INT_LIMBS}>> as LinearCodes<Int<INT_LIMBS>, Int<{8*INT_LIMBS}>>>::row_len(params.zip());
+            let codeword_len = <Zip<Int<INT_LIMBS>, Int<{2*INT_LIMBS}>> as LinearCodes<Int<INT_LIMBS>, Int<{8*INT_LIMBS}>>>::codeword_len(params.zip());
             b.iter(|| {
                 let _rows = BenchZip::encode_rows(&params, codeword_len, row_len, &poly);
             })
@@ -62,7 +62,7 @@ fn merkle_root<const P: usize>(group: &mut BenchmarkGroup<WallTime>, spec: usize
 
     let num_leaves = 1 << P;
     let leaves = (0..num_leaves)
-        .map(|_| CryptoInt::<INT_LIMBS>::random(&mut rng))
+        .map(|_| Int::<INT_LIMBS>::random(&mut rng))
         .collect_vec();
 
     group.bench_function(

--- a/src/biginteger/mod.rs
+++ b/src/biginteger/mod.rs
@@ -28,9 +28,9 @@ use zeroize::Zeroize;
 use crate::{
     adc,
     const_helpers::SerBuffer,
-    crypto_int::CryptoInt,
+    crypto_int::Int,
     field_config,
-    traits::{CryptoInteger, CryptoUinteger, FromBytes, Integer},
+    traits::{BigInteger, FromBytes, Integer, Uinteger},
 };
 
 #[macro_use]
@@ -585,7 +585,7 @@ impl<const N: usize> BigInt<N> {
     }
 }
 
-impl<const N: usize> Integer for BigInt<N> {
+impl<const N: usize> BigInteger for BigInt<N> {
     type W = Words<N>;
     fn to_words(&self) -> Words<N> {
         Words(self.0)
@@ -798,13 +798,13 @@ impl<const N: usize> From<BigInt<N>> for num_bigint::BigInt {
 }
 
 // Only returns the absolute value for the integer
-impl<const M: usize, const N: usize> From<CryptoInt<M>> for BigInt<N> {
-    fn from(value: CryptoInt<M>) -> Self {
+impl<const M: usize, const N: usize> From<Int<M>> for BigInt<N> {
+    fn from(value: Int<M>) -> Self {
         Self::from(&value)
     }
 }
-impl<const M: usize, const N: usize> From<&CryptoInt<M>> for BigInt<N> {
-    fn from(value: &CryptoInt<M>) -> Self {
+impl<const M: usize, const N: usize> From<&Int<M>> for BigInt<N> {
+    fn from(value: &Int<M>) -> Self {
         let abs = value.abs();
         let words = abs.to_words();
         let min_width = M.min(N);
@@ -816,21 +816,21 @@ impl<const M: usize, const N: usize> From<&CryptoInt<M>> for BigInt<N> {
     }
 }
 
-impl<const M: usize, const N: usize> From<BigInt<N>> for CryptoInt<M> {
-    fn from(value: BigInt<N>) -> CryptoInt<M> {
+impl<const M: usize, const N: usize> From<BigInt<N>> for Int<M> {
+    fn from(value: BigInt<N>) -> Int<M> {
         (&value).into()
     }
 }
 
-impl<const M: usize, const N: usize> From<&BigInt<N>> for CryptoInt<M> {
-    fn from(value: &BigInt<N>) -> CryptoInt<M> {
+impl<const M: usize, const N: usize> From<&BigInt<N>> for Int<M> {
+    fn from(value: &BigInt<N>) -> Int<M> {
         let words = value.to_words();
         let min_width = M.min(N);
 
         let mut result = [0u64; M];
         result[..min_width].copy_from_slice(&words[..min_width]);
 
-        CryptoInt::from_words(Words(result))
+        Int::from_words(Words(result))
     }
 }
 

--- a/src/ccs/ccs_f.rs
+++ b/src/ccs/ccs_f.rs
@@ -138,7 +138,7 @@ impl<F: Field> Statement_F<F> {
             .iter()
             .map(|M| {
                 compute_eval_table_sparse(M, evals, num_rows, num_cols, unsafe {
-                    F::Cr::new(ccs.config.load(Ordering::Acquire))
+                    F::R::new(ccs.config.load(Ordering::Acquire))
                 })
             })
             .collect()
@@ -191,11 +191,11 @@ impl<F: Field> Witness_F<F> {
 ///
 pub trait Instance_F<F: Field> {
     /// Given a witness vector, produce a concatonation of the statement and the witness
-    fn get_z_vector(&self, w: &[F], config: F::Cr) -> Vec<F>;
+    fn get_z_vector(&self, w: &[F], config: F::R) -> Vec<F>;
 }
 
 impl<F: Field> Instance_F<F> for Statement_F<F> {
-    fn get_z_vector(&self, w: &[F], config: F::Cr) -> Vec<F> {
+    fn get_z_vector(&self, w: &[F], config: F::R) -> Vec<F> {
         let mut z: Vec<F> = Vec::with_capacity(self.public_input.len() + w.len() + 1);
 
         z.extend_from_slice(&self.public_input);
@@ -207,7 +207,7 @@ impl<F: Field> Instance_F<F> for Statement_F<F> {
 }
 
 /// Returns a sparse matrix of field elements given a matrix of unsigned ints
-pub fn to_F_matrix<F: Field>(config: F::Cr, M: Vec<Vec<usize>>) -> SparseMatrix<F> {
+pub fn to_F_matrix<F: Field>(config: F::R, M: Vec<Vec<usize>>) -> SparseMatrix<F> {
     dense_matrix_to_sparse(
         M.iter()
             .map(|m| m.iter().map(|c| (*c as u64).map_to_field(config)).collect())
@@ -216,19 +216,19 @@ pub fn to_F_matrix<F: Field>(config: F::Cr, M: Vec<Vec<usize>>) -> SparseMatrix<
 }
 
 /// Returns a dense matrix of field elements given a matrix of unsigned ints
-pub fn to_F_dense_matrix<F: Field>(config: F::Cr, M: Vec<Vec<usize>>) -> Vec<Vec<F>> {
+pub fn to_F_dense_matrix<F: Field>(config: F::R, M: Vec<Vec<usize>>) -> Vec<Vec<F>> {
     M.iter()
         .map(|m| m.iter().map(|c| (*c as u64).map_to_field(config)).collect())
         .collect()
 }
 
 /// Returns a vector of field elements given a vector of unsigned ints
-pub fn to_F_vec<F: Field>(z: Vec<u64>, config: F::Cr) -> Vec<F> {
+pub fn to_F_vec<F: Field>(z: Vec<u64>, config: F::R) -> Vec<F> {
     z.iter().map(|c| (*c).map_to_field(config)).collect()
 }
 
 #[cfg(test)]
-pub(crate) fn get_test_ccs_F<F: Field>(config: F::Cr) -> CCS_F<F> {
+pub(crate) fn get_test_ccs_F<F: Field>(config: F::R) -> CCS_F<F> {
     use ark_std::log2;
 
     use crate::traits::FieldMap;
@@ -260,7 +260,7 @@ pub(crate) fn get_test_ccs_F<F: Field>(config: F::Cr) -> CCS_F<F> {
 }
 
 #[cfg(test)]
-pub(crate) fn get_test_ccs_F_statement<F: Field>(input: u64, config: F::Cr) -> Statement_F<F> {
+pub(crate) fn get_test_ccs_F_statement<F: Field>(input: u64, config: F::R) -> Statement_F<F> {
     let A = to_F_matrix(
         config,
         vec![
@@ -297,7 +297,7 @@ pub(crate) fn get_test_ccs_F_statement<F: Field>(input: u64, config: F::Cr) -> S
 }
 
 #[cfg(test)]
-pub(crate) fn get_test_z_F<F: Field>(input: u64, config: F::Cr) -> Vec<F> {
+pub(crate) fn get_test_z_F<F: Field>(input: u64, config: F::R) -> Vec<F> {
     // z = (io, 1, w)
     to_F_vec(
         vec![

--- a/src/ccs/test_utils.rs
+++ b/src/ccs/test_utils.rs
@@ -8,10 +8,10 @@ use super::{
 };
 use crate::{
     sparse_matrix::SparseMatrix,
-    traits::{ConfigReference, CryptoInteger, Field, FieldMap},
+    traits::{ConfigReference, Field, FieldMap, Integer},
 };
 
-pub(crate) fn create_dummy_identity_sparse_matrix_Z<I: CryptoInteger>(
+pub(crate) fn create_dummy_identity_sparse_matrix_Z<I: Integer>(
     rows: usize,
     columns: usize,
 ) -> SparseMatrix<I> {
@@ -27,7 +27,7 @@ pub(crate) fn create_dummy_identity_sparse_matrix_Z<I: CryptoInteger>(
 }
 
 // Takes a vector and returns a matrix that will square the vector
-pub(crate) fn create_dummy_squaring_sparse_matrix_Z<I: CryptoInteger>(
+pub(crate) fn create_dummy_squaring_sparse_matrix_Z<I: Integer>(
     rows: usize,
     columns: usize,
     witness: &[I],
@@ -51,7 +51,7 @@ pub(crate) fn create_dummy_squaring_sparse_matrix_Z<I: CryptoInteger>(
 pub(crate) fn create_dummy_identity_sparse_matrix_F<F: Field>(
     rows: usize,
     columns: usize,
-    config: F::Cr,
+    config: F::R,
 ) -> SparseMatrix<F> {
     let mut matrix = SparseMatrix {
         n_rows: rows,
@@ -86,7 +86,7 @@ pub(crate) fn create_dummy_squaring_sparse_matrix_F<F: Field>(
     matrix
 }
 
-fn get_dummy_ccs_Z_from_z<I: CryptoInteger>(
+fn get_dummy_ccs_Z_from_z<I: Integer>(
     z: &[I],
     pub_io_len: usize,
 ) -> (CCS_Z<I>, Statement_Z<I>, Witness_Z<I>) {
@@ -123,7 +123,7 @@ fn get_dummy_ccs_Z_from_z<I: CryptoInteger>(
 fn get_dummy_ccs_F_from_z<F: Field>(
     z: &[F],
     pub_io_len: usize,
-    config: F::Cr,
+    config: F::R,
 ) -> (CCS_F<F>, Statement_F<F>, Witness_F<F>) {
     let ccs = match config.pointer() {
         None => panic!("FieldConfig cannot be null"),
@@ -158,7 +158,7 @@ fn get_dummy_ccs_F_from_z<F: Field>(
     (ccs, statement, wit)
 }
 
-pub fn get_dummy_ccs_Z_from_z_length<I: CryptoInteger>(
+pub fn get_dummy_ccs_Z_from_z_length<I: Integer>(
     n: usize,
     rng: &mut impl Rng,
 ) -> (Vec<I>, CCS_Z<I>, Statement_Z<I>, Witness_Z<I>) {
@@ -173,7 +173,7 @@ pub fn get_dummy_ccs_Z_from_z_length<I: CryptoInteger>(
 pub fn get_dummy_ccs_F_from_z_length<F: Field>(
     n: usize,
     rng: &mut impl Rng,
-    config: F::Cr,
+    config: F::R,
 ) -> (Vec<F>, CCS_F<F>, Statement_F<F>, Witness_F<F>) {
     let mut z: Vec<_> = (0..n).map(|_| F::rand_with_config(rng, config)).collect();
     let pub_io_len = 1;

--- a/src/crypto_int/int.rs
+++ b/src/crypto_int/int.rs
@@ -6,24 +6,24 @@ use ark_std::{
 };
 use crypto_bigint::{
     subtle::{Choice, ConstantTimeEq},
-    Int, NonZero, Random,
+    Int as CryptoInt, NonZero, Random,
 };
 use num_traits::{ConstOne, ConstZero, One, Zero};
 
 use crate::{
     biginteger::{BigInt, Words},
-    crypto_int::uint::CryptoUint,
-    traits::CryptoInteger,
+    crypto_int::uint::Uint,
+    traits::Integer,
     zip::pcs::utils::ToBytes,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub struct CryptoInt<const N: usize>(pub(crate) Int<N>);
+pub struct Int<const N: usize>(pub(crate) CryptoInt<N>);
 
-impl<const N: usize> Zero for CryptoInt<N> {
+impl<const N: usize> Zero for Int<N> {
     #[inline]
     fn zero() -> Self {
-        Self(Int::zero())
+        Self(CryptoInt::zero())
     }
 
     #[inline]
@@ -32,7 +32,7 @@ impl<const N: usize> Zero for CryptoInt<N> {
     }
 }
 
-impl<const N: usize> Add<Self> for CryptoInt<N> {
+impl<const N: usize> Add<Self> for Int<N> {
     type Output = Self;
 
     #[inline]
@@ -41,22 +41,22 @@ impl<const N: usize> Add<Self> for CryptoInt<N> {
     }
 }
 
-impl<const N: usize> ConstZero for CryptoInt<N> {
-    const ZERO: Self = Self(Int::ZERO);
+impl<const N: usize> ConstZero for Int<N> {
+    const ZERO: Self = Self(CryptoInt::ZERO);
 }
 
-impl<const N: usize> One for CryptoInt<N> {
+impl<const N: usize> One for Int<N> {
     #[inline]
     fn one() -> Self {
-        Self(Int::one())
+        Self(CryptoInt::one())
     }
 }
 
-impl<const N: usize> ConstOne for CryptoInt<N> {
-    const ONE: Self = Self(Int::ONE);
+impl<const N: usize> ConstOne for Int<N> {
+    const ONE: Self = Self(CryptoInt::ONE);
 }
 
-impl<const N: usize> Mul<Self> for CryptoInt<N> {
+impl<const N: usize> Mul<Self> for Int<N> {
     type Output = Self;
 
     #[inline]
@@ -65,21 +65,21 @@ impl<const N: usize> Mul<Self> for CryptoInt<N> {
     }
 }
 
-impl<const N: usize> ConstantTimeEq for CryptoInt<N> {
+impl<const N: usize> ConstantTimeEq for Int<N> {
     #[inline]
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
     }
 }
 
-impl<const N: usize> PartialOrd for CryptoInt<N> {
+impl<const N: usize> PartialOrd for Int<N> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.0.partial_cmp(&other.0)
     }
 }
 
-impl<const N: usize> RemAssign<Self> for CryptoInt<N> {
+impl<const N: usize> RemAssign<Self> for Int<N> {
     #[inline]
     fn rem_assign(&mut self, rhs: Self) {
         self.0.rem_assign(
@@ -88,7 +88,7 @@ impl<const N: usize> RemAssign<Self> for CryptoInt<N> {
     }
 }
 
-impl<'a, const N: usize> Add<&'a Self> for CryptoInt<N> {
+impl<'a, const N: usize> Add<&'a Self> for Int<N> {
     type Output = Self;
 
     #[inline]
@@ -97,7 +97,7 @@ impl<'a, const N: usize> Add<&'a Self> for CryptoInt<N> {
     }
 }
 
-impl<'a, const N: usize> Mul<&'a Self> for CryptoInt<N> {
+impl<'a, const N: usize> Mul<&'a Self> for Int<N> {
     type Output = Self;
 
     #[inline]
@@ -106,14 +106,14 @@ impl<'a, const N: usize> Mul<&'a Self> for CryptoInt<N> {
     }
 }
 
-impl<'a, const N: usize> AddAssign<&'a Self> for CryptoInt<N> {
+impl<'a, const N: usize> AddAssign<&'a Self> for Int<N> {
     #[inline]
     fn add_assign(&mut self, rhs: &'a Self) {
         self.0 += &rhs.0;
     }
 }
 
-impl<'a, const N: usize> Sub<&'a Self> for CryptoInt<N> {
+impl<'a, const N: usize> Sub<&'a Self> for Int<N> {
     type Output = Self;
 
     #[inline]
@@ -122,56 +122,56 @@ impl<'a, const N: usize> Sub<&'a Self> for CryptoInt<N> {
     }
 }
 
-impl<const N: usize> From<i64> for CryptoInt<N> {
+impl<const N: usize> From<i64> for Int<N> {
     #[inline]
     fn from(value: i64) -> Self {
-        Self(Int::from(value))
+        Self(CryptoInt::from(value))
     }
 }
 
-impl<const N: usize> From<i32> for CryptoInt<N> {
+impl<const N: usize> From<i32> for Int<N> {
     #[inline]
     fn from(value: i32) -> Self {
-        Self(Int::from(value))
+        Self(CryptoInt::from(value))
     }
 }
 
-impl<const N: usize> From<i8> for CryptoInt<N> {
+impl<const N: usize> From<i8> for Int<N> {
     #[inline]
     fn from(value: i8) -> Self {
-        Self(Int::from(value))
+        Self(CryptoInt::from(value))
     }
 }
 
-impl<const N: usize> From<u8> for CryptoInt<N> {
+impl<const N: usize> From<u8> for Int<N> {
     #[inline]
     fn from(value: u8) -> Self {
-        Self(Int::from(value as i8))
+        Self(CryptoInt::from(value as i8))
     }
 }
 
-impl<const N: usize> Default for CryptoInt<N> {
+impl<const N: usize> Default for Int<N> {
     #[inline]
     fn default() -> Self {
-        Self(Int::default())
+        Self(CryptoInt::default())
     }
 }
 
-impl<const N: usize> Random for CryptoInt<N> {
+impl<const N: usize> Random for Int<N> {
     #[inline]
     fn random(rng: &mut (impl RngCore + ?Sized)) -> Self {
-        Self(Int::random(rng))
+        Self(CryptoInt::random(rng))
     }
 }
 
-impl<'a, const N: usize, const M: usize> From<&'a CryptoInt<M>> for CryptoInt<N> {
+impl<'a, const N: usize, const M: usize> From<&'a Int<M>> for Int<N> {
     #[inline]
-    fn from(value: &'a CryptoInt<M>) -> Self {
-        Self(Int::from(&value.0))
+    fn from(value: &'a Int<M>) -> Self {
+        Self(CryptoInt::from(&value.0))
     }
 }
 
-impl<const N: usize> ToBytes for CryptoInt<N> {
+impl<const N: usize> ToBytes for Int<N> {
     // Manual impl for generic type
     fn to_bytes(&self) -> Vec<u8> {
         self.0
@@ -182,13 +182,13 @@ impl<const N: usize> ToBytes for CryptoInt<N> {
     }
 }
 
-impl<const N: usize> CryptoInteger for CryptoInt<N> {
-    type W = crate::biginteger::Words<N>;
-    type Uint = CryptoUint<N>;
+impl<const N: usize> Integer for Int<N> {
+    type W = Words<N>;
+    type Uint = Uint<N>;
     type I = BigInt<N>;
 
     fn from_words(words: Words<N>) -> Self {
-        Self(Int::from_words(words.0))
+        Self(CryptoInt::from_words(words.0))
     }
 
     fn as_words(&self) -> &[u64] {
@@ -196,10 +196,10 @@ impl<const N: usize> CryptoInteger for CryptoInt<N> {
     }
 
     fn from_i64(value: i64) -> Self {
-        Self(Int::from_i64(value))
+        Self(CryptoInt::from_i64(value))
     }
 
     fn abs(&self) -> Self::Uint {
-        CryptoUint(self.0.abs())
+        Uint(self.0.abs())
     }
 }

--- a/src/crypto_int/mod.rs
+++ b/src/crypto_int/mod.rs
@@ -1,5 +1,5 @@
 mod int;
 mod uint;
 
-pub use int::CryptoInt;
-pub use uint::CryptoUint;
+pub use int::Int;
+pub use uint::Uint;

--- a/src/crypto_int/uint.rs
+++ b/src/crypto_int/uint.rs
@@ -1,18 +1,18 @@
 use ark_std::ops::{Mul, SubAssign};
-use crypto_bigint::{Integer, Odd, Uint};
+use crypto_bigint::{Integer, Odd, Uint as CryptoUint};
 use crypto_primes::hazmat::MillerRabin;
 use num_traits::One;
 
 use crate::{
     biginteger::Words,
-    crypto_int::CryptoInt,
-    traits::{types::PrimalityTest, CryptoUinteger, FromBytes},
+    crypto_int::Int,
+    traits::{types::PrimalityTest, FromBytes, Uinteger},
 };
 
 #[derive(Clone)]
-pub struct CryptoUint<const N: usize>(pub(crate) Uint<N>);
+pub struct Uint<const N: usize>(pub(crate) CryptoUint<N>);
 
-impl<const N: usize> Mul<Self> for CryptoUint<N> {
+impl<const N: usize> Mul<Self> for Uint<N> {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self::Output {
@@ -20,29 +20,29 @@ impl<const N: usize> Mul<Self> for CryptoUint<N> {
     }
 }
 
-impl<const N: usize> One for CryptoUint<N> {
+impl<const N: usize> One for Uint<N> {
     fn one() -> Self {
-        Self(Uint::ONE)
+        Self(CryptoUint::ONE)
     }
 }
 
-impl<'a, const N: usize> SubAssign<&'a Self> for CryptoUint<N> {
+impl<'a, const N: usize> SubAssign<&'a Self> for Uint<N> {
     fn sub_assign(&mut self, rhs: &'a Self) {
         self.0 -= rhs.0;
     }
 }
 
-impl<const N: usize> CryptoUinteger for CryptoUint<N> {
+impl<const N: usize> Uinteger for Uint<N> {
     type W = Words<N>;
-    type Int = CryptoInt<N>;
-    type PrimalityTest = MillerRabin<Uint<N>>;
+    type Int = Int<N>;
+    type PrimalityTest = MillerRabin<CryptoUint<N>>;
 
     fn from_words(words: Words<N>) -> Self {
-        Self(Uint::from_words(words.0))
+        Self(CryptoUint::from_words(words.0))
     }
 
     fn as_int(&self) -> Self::Int {
-        CryptoInt(self.0.as_int())
+        Int(self.0.as_int())
     }
 
     fn to_words(self) -> Words<N> {
@@ -54,20 +54,20 @@ impl<const N: usize> CryptoUinteger for CryptoUint<N> {
     }
 }
 
-impl<const N: usize> FromBytes for CryptoUint<N> {
+impl<const N: usize> FromBytes for Uint<N> {
     fn from_bytes_le(bytes: &[u8]) -> Option<Self> {
-        Some(Self(Uint::from_le_slice(bytes)))
+        Some(Self(CryptoUint::from_le_slice(bytes)))
     }
 
     fn from_bytes_be(bytes: &[u8]) -> Option<Self> {
-        Some(Self(Uint::from_be_slice(bytes)))
+        Some(Self(CryptoUint::from_be_slice(bytes)))
     }
 }
 
-impl<const N: usize> PrimalityTest<CryptoUint<N>> for MillerRabin<Uint<N>> {
-    type Inner = Uint<N>;
+impl<const N: usize> PrimalityTest<Uint<N>> for MillerRabin<CryptoUint<N>> {
+    type Inner = CryptoUint<N>;
 
-    fn new(candidate: CryptoUint<N>) -> Self {
+    fn new(candidate: Uint<N>) -> Self {
         Self::new(Odd::new(candidate.0).unwrap())
     }
 
@@ -75,18 +75,3 @@ impl<const N: usize> PrimalityTest<CryptoUint<N>> for MillerRabin<Uint<N>> {
         self.test_base_two().is_probably_prime()
     }
 }
-
-// pub(crate) struct MillerRabin<U: CryptoUinteger>(<Self as PrimalityTest<U>>::Inner) where MillerRabin<U>: PrimalityTest<U>;
-//
-// impl<const N: usize> PrimalityTest for MillerRabin<U> {
-//     type Inner = crypto_primes::hazmat::MillerRabin<U::GenericType>;
-//     fn new(candidate: U) -> Self {
-//         Self(
-//             crypto_primes::hazmat::MillerRabin::new(Odd::new(candidate.into_generic_type()).unwrap()),
-//         )
-//     }
-//
-//     fn is_probably_prime(&self) -> bool {
-//         self.0.test_base_two().is_probably_prime()
-//     }
-// }

--- a/src/field.rs
+++ b/src/field.rs
@@ -29,9 +29,9 @@ use RandomField::*;
 
 use crate::{
     biginteger::Words,
-    crypto_int::{CryptoInt, CryptoUint},
+    crypto_int::{Int, Uint},
     field_config::{ConfigRef, DebugFieldConfig},
-    traits::{Field, Integer},
+    traits::{BigInteger, Field},
     transcript::KeccakTranscript,
 };
 
@@ -272,23 +272,23 @@ impl<'cfg, const N: usize> RandomField<'cfg, N> {
 }
 
 impl<'cfg, const N: usize> Field for RandomField<'cfg, N> {
-    type I = BigInt<N>;
+    type B = BigInt<N>;
     type C = FieldConfig<N>;
-    type Cr = ConfigRef<'cfg, N>;
+    type R = ConfigRef<'cfg, N>;
     type W = Words<N>;
-    type CryptoInt = CryptoInt<N>;
-    type CryptoUint = CryptoUint<N>;
+    type I = Int<N>;
+    type U = Uint<N>;
     type DebugField = DebugRandomField;
 
     fn new_unchecked(config: ConfigRef<'cfg, N>, value: BigInt<N>) -> Self {
         Initialized { config, value }
     }
 
-    fn without_config(value: Self::I) -> Self {
+    fn without_config(value: Self::B) -> Self {
         Raw { value }
     }
 
-    fn rand_with_config<R: ark_std::rand::Rng + ?Sized>(rng: &mut R, config: Self::Cr) -> Self {
+    fn rand_with_config<R: ark_std::rand::Rng + ?Sized>(rng: &mut R, config: Self::R) -> Self {
         loop {
             let mut value = BigInt::rand(rng);
             let modulus = config
@@ -313,7 +313,7 @@ impl<'cfg, const N: usize> Field for RandomField<'cfg, N> {
         }
     }
 
-    fn set_config(&mut self, config: Self::Cr) {
+    fn set_config(&mut self, config: Self::R) {
         self.with_raw_value_mut_or(
             |value| {
                 // Ideally we should do something like:

--- a/src/field/conversion.rs
+++ b/src/field/conversion.rs
@@ -2,12 +2,11 @@ use ark_std::{vec::Vec, Zero};
 
 use crate::{
     biginteger::BigInt,
-    crypto_int::CryptoInt,
+    crypto_int::Int,
     field::{RandomField, RandomField::Raw},
     field_config::ConfigRef,
     traits::{
-        Config, ConfigReference, CryptoInteger, CryptoUinteger, Field, FieldMap, FromBytes,
-        Integer, Words,
+        BigInteger, Config, ConfigReference, Field, FieldMap, FromBytes, Integer, Uinteger, Words,
     },
 };
 
@@ -76,7 +75,7 @@ macro_rules! impl_field_map_for_int {
         impl<F: Field> FieldMap<F> for $t {
             type Output = F;
 
-            fn map_to_field(&self, config_ref: F::Cr) -> Self::Output {
+            fn map_to_field(&self, config_ref: F::R) -> Self::Output {
                 let config = match config_ref.reference() {
                     Some(config) => config,
                     None => {
@@ -91,11 +90,11 @@ macro_rules! impl_field_map_for_int {
                 if (ark_std::mem::size_of::<$t>() + 7) / 8 > 1 && F::W::num_words() > 1 {
                     words[1] = ((value as u128) >> 64) as u64;
                 }
-                let mut value = F::CryptoUint::from_words(words).as_int();
-                let modulus = F::CryptoInt::from_words(config.modulus().to_words());
+                let mut value = F::U::from_words(words).as_int();
+                let modulus = F::I::from_words(config.modulus().to_words());
 
                 value %= modulus;
-                let mut value = F::I::from(value);
+                let mut value = F::B::from(value);
                 config.mul_assign(&mut value, config.r2());
 
                 let mut r = F::new_unchecked(config_ref, value);
@@ -127,13 +126,13 @@ impl_field_map_for_int!(usize);
 impl<F: Field> FieldMap<F> for bool {
     type Output = F;
 
-    fn map_to_field(&self, config_ref: F::Cr) -> Self::Output {
+    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
         let config = match config_ref.reference() {
             Some(config) => config,
             None => panic!("Cannot convert boolean to prime field element without a modulus"),
         };
 
-        let mut r = F::I::from(*self as u64);
+        let mut r = F::B::from(*self as u64);
         config.mul_assign(&mut r, config.r2());
         F::new_unchecked(config_ref, r)
     }
@@ -141,19 +140,19 @@ impl<F: Field> FieldMap<F> for bool {
 
 impl<F: Field> FieldMap<F> for &bool {
     type Output = F;
-    fn map_to_field(&self, config_ref: F::Cr) -> Self::Output {
+    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
         (*self).map_to_field(config_ref)
     }
 }
 
 // Implementation for Int<N>
-impl<F: Field, T: CryptoInteger> FieldMap<F> for T
+impl<F: Field, T: Integer> FieldMap<F> for T
 where
     T::I: FieldMap<F, Output = F>,
 {
     type Output = F;
 
-    fn map_to_field(&self, config_ref: F::Cr) -> Self::Output {
+    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
         let local_type_bigint = T::I::from(self);
         let res = local_type_bigint.map_to_field(config_ref);
         if self < &<T as Zero>::zero() {
@@ -166,27 +165,27 @@ where
 // Implementation of FieldMap for BigInt<N>
 impl<F: Field, const M: usize> FieldMap<F> for BigInt<M>
 where
-    for<'a> CryptoInt<M>: From<&'a F::I>,
-    F::I: From<CryptoInt<M>>,
-    for<'a> F::CryptoInt: From<&'a BigInt<M>>,
+    for<'a> Int<M>: From<&'a F::B>,
+    F::B: From<Int<M>>,
+    for<'a> F::I: From<&'a BigInt<M>>,
 {
     type Output = F;
 
-    fn map_to_field(&self, config_ref: F::Cr) -> Self::Output {
+    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
         let config = match config_ref.reference() {
             Some(config) => config,
             None => panic!("Cannot convert BigInt to prime field element without a modulus"),
         };
 
         let mut value = if M > F::W::num_words() {
-            let modulus: CryptoInt<M> = config.modulus().into();
-            let mut value: CryptoInt<M> = self.into();
+            let modulus: Int<M> = config.modulus().into();
+            let mut value: Int<M> = self.into();
             value %= modulus;
 
-            F::I::from(value)
+            F::B::from(value)
         } else {
-            let modulus: F::CryptoInt = config.modulus().into();
-            let mut value: F::CryptoInt = self.into();
+            let modulus: F::I = config.modulus().into();
+            let mut value: F::I = self.into();
             value %= modulus;
 
             value.into()
@@ -204,7 +203,7 @@ where
     BigInt<M>: FieldMap<F, Output = F>,
 {
     type Output = F;
-    fn map_to_field(&self, config_ref: F::Cr) -> Self::Output {
+    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
         (*self).map_to_field(config_ref)
     }
 }
@@ -214,7 +213,7 @@ where
 impl<F: Field, T: FieldMap<F>> FieldMap<F> for Vec<T> {
     type Output = Vec<T::Output>;
 
-    fn map_to_field(&self, config_ref: F::Cr) -> Self::Output {
+    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
         self.iter().map(|x| x.map_to_field(config_ref)).collect()
     }
 }
@@ -222,7 +221,7 @@ impl<F: Field, T: FieldMap<F>> FieldMap<F> for Vec<T> {
 impl<F: Field, T: FieldMap<F>> FieldMap<F> for &Vec<T> {
     type Output = Vec<T::Output>;
 
-    fn map_to_field(&self, config_ref: F::Cr) -> Self::Output {
+    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
         self.iter().map(|x| x.map_to_field(config_ref)).collect()
     }
 }
@@ -230,7 +229,7 @@ impl<F: Field, T: FieldMap<F>> FieldMap<F> for &Vec<T> {
 impl<F: Field, T: FieldMap<F>> FieldMap<F> for &[T] {
     type Output = Vec<T::Output>;
 
-    fn map_to_field(&self, config_ref: F::Cr) -> Self::Output {
+    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
         self.iter().map(|x| x.map_to_field(config_ref)).collect()
     }
 }
@@ -248,13 +247,13 @@ mod tests {
 
     fn test_from<F: Field + From<T>, T: Clone>(value: T, value_str: &str)
     where
-        F::I: FromStr,
-        <F::I as FromStr>::Err: Debug,
+        F::B: FromStr,
+        <F::B as FromStr>::Err: Debug,
     {
         let raw_element = F::from(value);
         assert_eq!(
             raw_element,
-            F::without_config(F::I::from_str(value_str).unwrap())
+            F::without_config(F::B::from_str(value_str).unwrap())
         )
     }
 

--- a/src/poly/util.rs
+++ b/src/poly/util.rs
@@ -24,7 +24,7 @@ pub fn gen_eval_point<F: Field>(
     index: usize,
     index_len: usize,
     point: &[F],
-    config: F::Cr,
+    config: F::R,
 ) -> Vec<F> {
     let index_vec: Vec<F> = bit_decompose(index as u64, index_len)
         .into_iter()

--- a/src/poly_f/mle/dense.rs
+++ b/src/poly_f/mle/dense.rs
@@ -24,15 +24,15 @@ pub struct DenseMultilinearExtension<F: Field> {
     /// Number of variables
     pub num_vars: usize,
     /// Field in which the MLE is operating
-    pub config: F::Cr,
+    pub config: F::R,
 }
 
 impl<F: Field> DenseMultilinearExtension<F> {
-    pub fn from_evaluations_slice(num_vars: usize, evaluations: &[F], config: F::Cr) -> Self {
+    pub fn from_evaluations_slice(num_vars: usize, evaluations: &[F], config: F::R) -> Self {
         Self::from_evaluations_vec(num_vars, evaluations.to_vec(), config)
     }
 
-    pub fn evaluate(&self, point: &[F], config: F::Cr) -> Option<F> {
+    pub fn evaluate(&self, point: &[F], config: F::R) -> Option<F> {
         if point.len() == self.num_vars {
             Some(self.fixed_variables(point, config)[0].clone())
         } else {
@@ -40,7 +40,7 @@ impl<F: Field> DenseMultilinearExtension<F> {
         }
     }
 
-    pub fn from_evaluations_vec(num_vars: usize, evaluations: Vec<F>, config: F::Cr) -> Self {
+    pub fn from_evaluations_vec(num_vars: usize, evaluations: Vec<F>, config: F::R) -> Self {
         // assert that the number of variables matches the size of evaluations
         assert!(
             evaluations.len() <= 1 << num_vars,
@@ -65,7 +65,7 @@ impl<F: Field> DenseMultilinearExtension<F> {
     }
 
     /// Returns the dense MLE from the given matrix, without modifying the original matrix.
-    pub fn from_matrix(matrix: &SparseMatrix<F>, config: F::Cr) -> Self {
+    pub fn from_matrix(matrix: &SparseMatrix<F>, config: F::R) -> Self {
         let n_vars: usize = (log2(matrix.nrows()) + log2(matrix.ncols())) as usize; // n_vars = s + s'
 
         // Matrices might need to get padded before turned into an MLE
@@ -86,7 +86,7 @@ impl<F: Field> DenseMultilinearExtension<F> {
     }
 
     /// Takes n_vars and a dense slice and returns its dense MLE.
-    pub fn from_slice(n_vars: usize, v: &[F], config: F::Cr) -> Self {
+    pub fn from_slice(n_vars: usize, v: &[F], config: F::R) -> Self {
         let v_padded: Vec<F> = if v.len() != (1 << n_vars) {
             // pad to 2^n_vars
             [
@@ -126,7 +126,7 @@ impl<F: Field> MultilinearExtension<F> for DenseMultilinearExtension<F> {
         self.num_vars
     }
 
-    fn rand<Rn: rand::Rng>(num_vars: usize, config: F::Cr, rng: &mut Rn) -> Self {
+    fn rand<Rn: rand::Rng>(num_vars: usize, config: F::R, rng: &mut Rn) -> Self {
         Self::from_evaluations_vec(
             num_vars,
             (0..1 << num_vars).map(|_| F::random(rng)).collect(),
@@ -140,7 +140,7 @@ impl<F: Field> MultilinearExtension<F> for DenseMultilinearExtension<F> {
         copy
     }
 
-    fn fix_variables(&mut self, partial_point: &[F], _config: F::Cr) {
+    fn fix_variables(&mut self, partial_point: &[F], _config: F::R) {
         assert!(
             partial_point.len() <= self.num_vars,
             "too many partial points"
@@ -168,7 +168,7 @@ impl<F: Field> MultilinearExtension<F> for DenseMultilinearExtension<F> {
         self.num_vars = nv - dim;
     }
 
-    fn fixed_variables(&self, partial_point: &[F], config: F::Cr) -> Self {
+    fn fixed_variables(&self, partial_point: &[F], config: F::R) -> Self {
         let mut res = self.clone();
         res.fix_variables(partial_point, config);
         res
@@ -184,7 +184,7 @@ impl<F: Field> Zero for DenseMultilinearExtension<F> {
         Self {
             num_vars: 0,
             evaluations: vec![F::zero()],
-            config: F::Cr::NONE,
+            config: F::R::NONE,
         }
     }
 

--- a/src/poly_f/mle/mod.rs
+++ b/src/poly_f/mle/mod.rs
@@ -35,7 +35,7 @@ pub trait MultilinearExtension<F: Field>:
 
     /// Outputs an `l`-variate multilinear extension where value of evaluations
     /// are sampled uniformly at random.
-    fn rand<Rn: Rng>(num_vars: usize, config: F::Cr, rng: &mut Rn) -> Self;
+    fn rand<Rn: Rng>(num_vars: usize, config: F::R, rng: &mut Rn) -> Self;
 
     /// Relabel the point by swapping `k` scalars from positions `a..a+k` to
     /// positions `b..b+k`, and from position `b..b+k` to position `a..a+k`
@@ -47,11 +47,11 @@ pub trait MultilinearExtension<F: Field>:
 
     /// Reduce the number of variables of `self` by fixing the
     /// `partial_point.len()` variables at `partial_point`.
-    fn fix_variables(&mut self, partial_point: &[F], config: F::Cr);
+    fn fix_variables(&mut self, partial_point: &[F], config: F::R);
 
     /// Creates a new object with the number of variables of `self` reduced by fixing the
     /// `partial_point.len()` variables at `partial_point`.
-    fn fixed_variables(&self, partial_point: &[F], config: F::Cr) -> Self;
+    fn fixed_variables(&self, partial_point: &[F], config: F::R) -> Self;
 
     /// Returns a list of evaluations over the domain, which is the boolean
     /// hypercube. The evaluations are in little-endian order.

--- a/src/poly_f/mle/sparse.rs
+++ b/src/poly_f/mle/sparse.rs
@@ -15,7 +15,7 @@ use rayon::iter::*;
 use super::{swap_bits, MultilinearExtension};
 use crate::{
     sparse_matrix::SparseMatrix,
-    traits::{ConfigReference, Field, FieldMap, Integer},
+    traits::{BigInteger, ConfigReference, Field, FieldMap},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -26,13 +26,13 @@ pub struct SparseMultilinearExtension<F: Field> {
     pub num_vars: usize,
     zero: F,
     /// Field in which the MLE is operating
-    pub config: F::Cr,
+    pub config: F::R,
 }
 impl<F: Field> SparseMultilinearExtension<F> {
     pub fn from_evaluations<'a>(
         num_vars: usize,
         evaluations: impl IntoIterator<Item = &'a (usize, F)>,
-        config: F::Cr,
+        config: F::R,
     ) -> Self
     where
         F: 'a,
@@ -53,7 +53,7 @@ impl<F: Field> SparseMultilinearExtension<F> {
             config,
         }
     }
-    pub fn evaluate(&self, point: &[F], config: F::Cr) -> F {
+    pub fn evaluate(&self, point: &[F], config: F::R) -> F {
         assert!(point.len() == self.num_vars);
         self.fixed_variables(point, config)[0].clone()
     }
@@ -68,7 +68,7 @@ impl<F: Field> SparseMultilinearExtension<F> {
     pub fn rand_with_config<Rn: Rng>(
         num_vars: usize,
         num_nonzero_entries: usize,
-        config: F::Cr,
+        config: F::R,
         rng: &mut Rn,
     ) -> Self {
         assert!(num_nonzero_entries <= 1 << num_vars);
@@ -97,7 +97,7 @@ impl<F: Field> SparseMultilinearExtension<F> {
     }
 
     /// Returns the sparse MLE from the given matrix, without modifying the original matrix.
-    pub fn from_matrix(m: &SparseMatrix<F>, config: F::Cr) -> Self {
+    pub fn from_matrix(m: &SparseMatrix<F>, config: F::R) -> Self {
         let n_rows = m.n_rows.next_power_of_two();
         let n_cols = m.n_cols.next_power_of_two();
         let n_vars: usize = (log2(n_rows * n_cols)) as usize; // n_vars = s + s'
@@ -118,12 +118,12 @@ impl<F: Field> SparseMultilinearExtension<F> {
     }
 
     /// Takes n_vars and a sparse slice and returns its sparse MLE.
-    pub fn from_sparse_slice(n_vars: usize, v: &[(usize, F)], config: F::Cr) -> Self {
+    pub fn from_sparse_slice(n_vars: usize, v: &[(usize, F)], config: F::R) -> Self {
         SparseMultilinearExtension::<F>::from_evaluations(n_vars, v, config)
     }
 
     /// Takes n_vars and a dense slice and returns its sparse MLE.
-    pub fn from_slice(n_vars: usize, v: &[F], config: F::Cr) -> Self {
+    pub fn from_slice(n_vars: usize, v: &[F], config: F::R) -> Self {
         let v_sparse = v
             .iter()
             .enumerate()
@@ -141,7 +141,7 @@ impl<F: Field> MultilinearExtension<F> for SparseMultilinearExtension<F> {
     /// are sampled uniformly at random. The number of nonzero entries is
     /// `sqrt(2^num_vars)` and indices of those nonzero entries are distributed
     /// uniformly at random.
-    fn rand<Rn: ark_std::rand::Rng>(num_vars: usize, config: F::Cr, rng: &mut Rn) -> Self {
+    fn rand<Rn: ark_std::rand::Rng>(num_vars: usize, config: F::R, rng: &mut Rn) -> Self {
         Self::rand_with_config(num_vars, 1 << (num_vars / 2), config, rng)
     }
 
@@ -170,7 +170,7 @@ impl<F: Field> MultilinearExtension<F> for SparseMultilinearExtension<F> {
         }
     }
 
-    fn fix_variables(&mut self, partial_point: &[F], config: F::Cr) {
+    fn fix_variables(&mut self, partial_point: &[F], config: F::R) {
         let dim = partial_point.len();
         assert!(dim <= self.num_vars, "invalid partial point dimension");
 
@@ -209,7 +209,7 @@ impl<F: Field> MultilinearExtension<F> for SparseMultilinearExtension<F> {
         self.zero = F::zero();
     }
 
-    fn fixed_variables(&self, partial_point: &[F], config: F::Cr) -> Self {
+    fn fixed_variables(&self, partial_point: &[F], config: F::R) -> Self {
         let mut res = self.clone();
         res.fix_variables(partial_point, config);
         res
@@ -232,7 +232,7 @@ impl<F: Field> Zero for SparseMultilinearExtension<F> {
             num_vars: 0,
             evaluations: tuples_to_treemap(&Vec::new()),
             zero: F::zero(),
-            config: F::Cr::NONE,
+            config: F::R::NONE,
         }
     }
 
@@ -397,10 +397,10 @@ fn hashmap_to_treemap<F: Field>(map: &HashMap<usize, F>) -> BTreeMap<usize, F> {
 }
 
 // precompute  f(x) = eq(g,x)
-fn precompute_eq<F: Field>(g: &[F], config: F::Cr) -> Vec<F> {
+fn precompute_eq<F: Field>(g: &[F], config: F::R) -> Vec<F> {
     let dim = g.len();
     let mut dp = vec![F::zero(); 1 << dim];
-    dp[0] = <F::I as FieldMap<F>>::map_to_field(&F::I::one(), config) - g[0].clone();
+    dp[0] = <F::B as FieldMap<F>>::map_to_field(&F::B::one(), config) - g[0].clone();
     dp[1] = g[0].clone();
     for i in 1..dim {
         for b in 0..1 << i {
@@ -423,7 +423,7 @@ mod tests {
     };
 
     // Function to convert usize to a binary vector of Ring elements.
-    fn usize_to_binary_vector<F: Field>(n: usize, dimensions: usize, config: F::Cr) -> Vec<F> {
+    fn usize_to_binary_vector<F: Field>(n: usize, dimensions: usize, config: F::R) -> Vec<F> {
         let mut bits = Vec::with_capacity(dimensions);
         let mut current = n;
 
@@ -439,18 +439,18 @@ mod tests {
     }
 
     // Wrapper function to generate a boolean hypercube.
-    fn boolean_hypercube<F: Field>(dimensions: usize, config: F::Cr) -> Vec<Vec<F>> {
+    fn boolean_hypercube<F: Field>(dimensions: usize, config: F::R) -> Vec<Vec<F>> {
         let max_val = 1 << dimensions; // 2^dimensions
         (0..max_val)
             .map(|i| usize_to_binary_vector(i, dimensions, config))
             .collect()
     }
 
-    fn vec_cast<F: Field>(v: &[usize], config: F::Cr) -> Vec<F> {
+    fn vec_cast<F: Field>(v: &[usize], config: F::R) -> Vec<F> {
         v.iter().map(|c| (*c as u64).map_to_field(config)).collect()
     }
 
-    fn matrix_cast<F: Field>(m: &[Vec<usize>], config: F::Cr) -> SparseMatrix<F> {
+    fn matrix_cast<F: Field>(m: &[Vec<usize>], config: F::R) -> SparseMatrix<F> {
         let n_rows = m.len();
         let n_cols = m[0].len();
         let mut coeffs = Vec::with_capacity(n_rows);
@@ -470,7 +470,7 @@ mod tests {
         }
     }
 
-    fn get_test_z<F: Field>(input: usize, config: F::Cr) -> Vec<F> {
+    fn get_test_z<F: Field>(input: usize, config: F::R) -> Vec<F> {
         vec_cast(
             &[
                 input, // io

--- a/src/poly_f/polynomials/multilinear_polynomial.rs
+++ b/src/poly_f/polynomials/multilinear_polynomial.rs
@@ -21,7 +21,7 @@ pub fn random_mle_list<F: Field, Rn: RngCore>(
     nv: usize,
     degree: usize,
     rng: &mut Rn,
-    config: F::Cr,
+    config: F::R,
 ) -> (Vec<RefCounter<DenseMultilinearExtension<F>>>, F) {
     let start = start_timer!(|| "sample random mle list");
     let mut multiplicands = Vec::with_capacity(degree);
@@ -59,7 +59,7 @@ pub fn random_zero_mle_list<F: Field, Rn: RngCore>(
     nv: usize,
     degree: usize,
     rng: &mut Rn,
-    config: F::Cr,
+    config: F::R,
 ) -> Vec<RefCounter<DenseMultilinearExtension<F>>> {
     let start = start_timer!(|| "sample random zero mle list");
 
@@ -87,7 +87,7 @@ pub fn random_zero_mle_list<F: Field, Rn: RngCore>(
     list
 }
 
-pub fn identity_permutation<F: Field>(num_vars: usize, num_chunks: usize, config: F::Cr) -> Vec<F> {
+pub fn identity_permutation<F: Field>(num_vars: usize, num_chunks: usize, config: F::R) -> Vec<F> {
     let len = (num_chunks as u64) * (1u64 << num_vars);
     (0..len).map(|i| i.map_to_field(config)).collect()
 }
@@ -96,7 +96,7 @@ pub fn identity_permutation<F: Field>(num_vars: usize, num_chunks: usize, config
 pub fn identity_permutation_mles<F: Field>(
     num_vars: usize,
     num_chunks: usize,
-    config: F::Cr,
+    config: F::R,
 ) -> Vec<RefCounter<DenseMultilinearExtension<F>>> {
     let mut res = vec![];
     for i in 0..num_chunks {
@@ -115,7 +115,7 @@ pub fn random_permutation<F: Field, Rn: RngCore>(
     num_vars: usize,
     num_chunks: usize,
     rng: &mut Rn,
-    config: F::Cr,
+    config: F::R,
 ) -> Vec<F> {
     let len = (num_chunks as u64) * (1u64 << num_vars);
     let mut s_id_vec: Vec<F> = (0..len).map(|i| i.map_to_field(config)).collect();
@@ -132,7 +132,7 @@ pub fn random_permutation_mles<F: Field, Rn: RngCore>(
     num_vars: usize,
     num_chunks: usize,
     rng: &mut Rn,
-    config: F::Cr,
+    config: F::R,
 ) -> Vec<RefCounter<DenseMultilinearExtension<F>>> {
     let s_perm_vec = random_permutation(num_vars, num_chunks, rng, config);
     let mut res = vec![];
@@ -149,11 +149,7 @@ pub fn random_permutation_mles<F: Field, Rn: RngCore>(
     res
 }
 
-pub fn evaluate_opt<F: Field>(
-    poly: &DenseMultilinearExtension<F>,
-    point: &[F],
-    config: F::Cr,
-) -> F {
+pub fn evaluate_opt<F: Field>(poly: &DenseMultilinearExtension<F>, point: &[F], config: F::R) -> F {
     assert_eq!(poly.num_vars, point.len());
     fix_variables(poly, point, config).evaluations[0].clone()
 }
@@ -161,7 +157,7 @@ pub fn evaluate_opt<F: Field>(
 pub fn fix_variables<F: Field>(
     poly: &DenseMultilinearExtension<F>,
     partial_point: &[F],
-    config: F::Cr,
+    config: F::R,
 ) -> DenseMultilinearExtension<F> {
     assert!(
         partial_point.len() <= poly.num_vars,
@@ -197,7 +193,7 @@ fn fix_one_variable_helper<F: Field>(data: &[F], nv: usize, point: &F) -> Vec<F>
 pub fn evaluate_no_par<F: Field>(
     poly: &DenseMultilinearExtension<F>,
     point: &[F],
-    config: F::Cr,
+    config: F::R,
 ) -> F {
     assert_eq!(poly.num_vars, point.len());
     fix_variables_no_par(poly, point, config).evaluations[0].clone()
@@ -206,7 +202,7 @@ pub fn evaluate_no_par<F: Field>(
 fn fix_variables_no_par<F: Field>(
     poly: &DenseMultilinearExtension<F>,
     partial_point: &[F],
-    config: F::Cr,
+    config: F::R,
 ) -> DenseMultilinearExtension<F> {
     assert!(
         partial_point.len() <= poly.num_vars,
@@ -230,7 +226,7 @@ fn fix_variables_no_par<F: Field>(
 /// polynomials do not share a same number of nvs.
 pub fn merge_polynomials<F: Field>(
     polynomials: &[RefCounter<DenseMultilinearExtension<F>>],
-    config: F::Cr,
+    config: F::R,
 ) -> Result<RefCounter<DenseMultilinearExtension<F>>, ArithErrors> {
     let nv = polynomials[0].num_vars();
     for poly in polynomials.iter() {
@@ -255,7 +251,7 @@ pub fn merge_polynomials<F: Field>(
 pub fn fix_last_variables_no_par<F: Field>(
     poly: &DenseMultilinearExtension<F>,
     partial_point: &[F],
-    config: F::Cr,
+    config: F::R,
 ) -> DenseMultilinearExtension<F> {
     let mut res = fix_last_variable_no_par(poly, partial_point.last().unwrap(), config);
     for p in partial_point.iter().rev().skip(1) {
@@ -267,7 +263,7 @@ pub fn fix_last_variables_no_par<F: Field>(
 fn fix_last_variable_no_par<F: Field>(
     poly: &DenseMultilinearExtension<F>,
     partial_point: &F,
-    config: F::Cr,
+    config: F::R,
 ) -> DenseMultilinearExtension<F> {
     let nv = poly.num_vars();
     let half_len = 1 << (nv - 1);
@@ -282,7 +278,7 @@ fn fix_last_variable_no_par<F: Field>(
 pub fn fix_last_variables<F: Field>(
     poly: &DenseMultilinearExtension<F>,
     partial_point: &[F],
-    config: F::Cr,
+    config: F::R,
 ) -> DenseMultilinearExtension<F> {
     assert!(
         partial_point.len() <= poly.num_vars,

--- a/src/poly_z/mle/dense.rs
+++ b/src/poly_z/mle/dense.rs
@@ -16,7 +16,7 @@ use crate::{
     poly::ArithErrors,
     poly_f::mle::DenseMultilinearExtension as DenseMultilinearExtensionF,
     sparse_matrix::SparseMatrix,
-    traits::{CryptoInteger, Field, FieldMap},
+    traits::{Field, FieldMap, Integer},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,7 +27,7 @@ pub struct DenseMultilinearExtension<I> {
     pub num_vars: usize,
 }
 
-impl<I: CryptoInteger> DenseMultilinearExtension<I> {
+impl<I: Integer> DenseMultilinearExtension<I> {
     pub fn from_evaluations_slice(num_vars: usize, evaluations: &[I]) -> Self {
         Self::from_evaluations_vec(num_vars, evaluations.to_vec())
     }
@@ -119,12 +119,12 @@ impl<I: CryptoInteger> DenseMultilinearExtension<I> {
     }
 }
 
-impl<F: Field, I: CryptoInteger> FieldMap<F> for DenseMultilinearExtension<I>
+impl<F: Field, I: Integer> FieldMap<F> for DenseMultilinearExtension<I>
 where
     I: FieldMap<F, Output = F>,
 {
     type Output = DenseMultilinearExtensionF<F>;
-    fn map_to_field(&self, config_ref: F::Cr) -> Self::Output {
+    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
         DenseMultilinearExtensionF::from_evaluations_vec(
             self.num_vars,
             self.evaluations.map_to_field(config_ref),
@@ -133,7 +133,7 @@ where
     }
 }
 
-impl<I: CryptoInteger> MultilinearExtension<I> for DenseMultilinearExtension<I> {
+impl<I: Integer> MultilinearExtension<I> for DenseMultilinearExtension<I> {
     fn num_vars(&self) -> usize {
         self.num_vars
     }
@@ -190,7 +190,7 @@ impl<I: CryptoInteger> MultilinearExtension<I> for DenseMultilinearExtension<I> 
     }
 }
 
-impl<I: CryptoInteger> Zero for DenseMultilinearExtension<I> {
+impl<I: Integer> Zero for DenseMultilinearExtension<I> {
     fn zero() -> Self {
         Self {
             num_vars: 0,
@@ -203,7 +203,7 @@ impl<I: CryptoInteger> Zero for DenseMultilinearExtension<I> {
     }
 }
 
-impl<I: CryptoInteger> Add for DenseMultilinearExtension<I> {
+impl<I: Integer> Add for DenseMultilinearExtension<I> {
     type Output = DenseMultilinearExtension<I>;
 
     fn add(self, other: DenseMultilinearExtension<I>) -> Self {
@@ -211,7 +211,7 @@ impl<I: CryptoInteger> Add for DenseMultilinearExtension<I> {
     }
 }
 
-impl<'a, I: CryptoInteger> Add<&'a DenseMultilinearExtension<I>> for &DenseMultilinearExtension<I> {
+impl<'a, I: Integer> Add<&'a DenseMultilinearExtension<I>> for &DenseMultilinearExtension<I> {
     type Output = DenseMultilinearExtension<I>;
 
     fn add(self, rhs: &'a DenseMultilinearExtension<I>) -> Self::Output {
@@ -237,15 +237,13 @@ impl<'a, I: CryptoInteger> Add<&'a DenseMultilinearExtension<I>> for &DenseMulti
     }
 }
 
-impl<I: CryptoInteger> AddAssign for DenseMultilinearExtension<I> {
+impl<I: Integer> AddAssign for DenseMultilinearExtension<I> {
     fn add_assign(&mut self, rhs: DenseMultilinearExtension<I>) {
         self.add_assign(&rhs);
     }
 }
 
-impl<'a, I: CryptoInteger> AddAssign<&'a DenseMultilinearExtension<I>>
-    for DenseMultilinearExtension<I>
-{
+impl<'a, I: Integer> AddAssign<&'a DenseMultilinearExtension<I>> for DenseMultilinearExtension<I> {
     fn add_assign(&mut self, other: &'a DenseMultilinearExtension<I>) {
         if self.is_zero() {
             *self = other.clone();
@@ -267,9 +265,7 @@ impl<'a, I: CryptoInteger> AddAssign<&'a DenseMultilinearExtension<I>>
     }
 }
 
-impl<I: CryptoInteger> AddAssign<(I, &DenseMultilinearExtension<I>)>
-    for DenseMultilinearExtension<I>
-{
+impl<I: Integer> AddAssign<(I, &DenseMultilinearExtension<I>)> for DenseMultilinearExtension<I> {
     fn add_assign(&mut self, (r, other): (I, &DenseMultilinearExtension<I>)) {
         if self.is_zero() {
             *self = other.clone();
@@ -294,7 +290,7 @@ impl<I: CryptoInteger> AddAssign<(I, &DenseMultilinearExtension<I>)>
     }
 }
 
-impl<I: CryptoInteger> Neg for DenseMultilinearExtension<I> {
+impl<I: Integer> Neg for DenseMultilinearExtension<I> {
     type Output = DenseMultilinearExtension<I>;
 
     fn neg(mut self) -> Self {
@@ -304,7 +300,7 @@ impl<I: CryptoInteger> Neg for DenseMultilinearExtension<I> {
     }
 }
 
-impl<I: CryptoInteger> Sub for DenseMultilinearExtension<I> {
+impl<I: Integer> Sub for DenseMultilinearExtension<I> {
     type Output = Self;
 
     fn sub(self, other: DenseMultilinearExtension<I>) -> Self {
@@ -312,7 +308,7 @@ impl<I: CryptoInteger> Sub for DenseMultilinearExtension<I> {
     }
 }
 
-impl<'a, I: CryptoInteger> Sub<&'a DenseMultilinearExtension<I>> for &DenseMultilinearExtension<I> {
+impl<'a, I: Integer> Sub<&'a DenseMultilinearExtension<I>> for &DenseMultilinearExtension<I> {
     type Output = DenseMultilinearExtension<I>;
 
     fn sub(self, rhs: &'a DenseMultilinearExtension<I>) -> Self::Output {
@@ -338,15 +334,13 @@ impl<'a, I: CryptoInteger> Sub<&'a DenseMultilinearExtension<I>> for &DenseMulti
     }
 }
 
-impl<I: CryptoInteger> SubAssign for DenseMultilinearExtension<I> {
+impl<I: Integer> SubAssign for DenseMultilinearExtension<I> {
     fn sub_assign(&mut self, other: DenseMultilinearExtension<I>) {
         self.sub_assign(&other);
     }
 }
 
-impl<'a, I: CryptoInteger> SubAssign<&'a DenseMultilinearExtension<I>>
-    for DenseMultilinearExtension<I>
-{
+impl<'a, I: Integer> SubAssign<&'a DenseMultilinearExtension<I>> for DenseMultilinearExtension<I> {
     fn sub_assign(&mut self, rhs: &'a DenseMultilinearExtension<I>) {
         if self.is_zero() {
             *self = rhs.clone().neg();
@@ -368,7 +362,7 @@ impl<'a, I: CryptoInteger> SubAssign<&'a DenseMultilinearExtension<I>>
     }
 }
 
-impl<I: CryptoInteger> Mul<I> for DenseMultilinearExtension<I> {
+impl<I: Integer> Mul<I> for DenseMultilinearExtension<I> {
     type Output = DenseMultilinearExtension<I>;
 
     fn mul(mut self, rhs: I) -> DenseMultilinearExtension<I> {
@@ -380,7 +374,7 @@ impl<I: CryptoInteger> Mul<I> for DenseMultilinearExtension<I> {
     }
 }
 
-impl<I: CryptoInteger> MulAssign<I> for DenseMultilinearExtension<I> {
+impl<I: Integer> MulAssign<I> for DenseMultilinearExtension<I> {
     fn mul_assign(&mut self, rhs: I) {
         self.evaluations
             .iter_mut()
@@ -388,7 +382,7 @@ impl<I: CryptoInteger> MulAssign<I> for DenseMultilinearExtension<I> {
     }
 }
 
-impl<I: CryptoInteger> Sub<I> for DenseMultilinearExtension<I> {
+impl<I: Integer> Sub<I> for DenseMultilinearExtension<I> {
     type Output = DenseMultilinearExtension<I>;
 
     fn sub(mut self, rhs: I) -> DenseMultilinearExtension<I> {
@@ -400,7 +394,7 @@ impl<I: CryptoInteger> Sub<I> for DenseMultilinearExtension<I> {
     }
 }
 
-impl<I: CryptoInteger> Add<I> for DenseMultilinearExtension<I> {
+impl<I: Integer> Add<I> for DenseMultilinearExtension<I> {
     type Output = DenseMultilinearExtension<I>;
 
     fn add(mut self, rhs: I) -> DenseMultilinearExtension<I> {
@@ -410,7 +404,7 @@ impl<I: CryptoInteger> Add<I> for DenseMultilinearExtension<I> {
     }
 }
 
-impl<I: CryptoInteger> Index<usize> for DenseMultilinearExtension<I> {
+impl<I: Integer> Index<usize> for DenseMultilinearExtension<I> {
     type Output = I;
 
     fn index(&self, index: usize) -> &Self::Output {
@@ -418,7 +412,7 @@ impl<I: CryptoInteger> Index<usize> for DenseMultilinearExtension<I> {
     }
 }
 
-impl<I: CryptoInteger> IndexMut<usize> for DenseMultilinearExtension<I> {
+impl<I: Integer> IndexMut<usize> for DenseMultilinearExtension<I> {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.evaluations[index]
     }
@@ -434,9 +428,7 @@ unsafe impl<I> Sync for DenseMultilinearExtension<I> {}
 ///      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
 /// over r, which is
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
-pub fn build_eq_x_r<I: CryptoInteger>(
-    r: &[I],
-) -> Result<DenseMultilinearExtension<I>, ArithErrors> {
+pub fn build_eq_x_r<I: Integer>(r: &[I]) -> Result<DenseMultilinearExtension<I>, ArithErrors> {
     let evals = build_eq_x_r_vec(r)?;
     let mle = DenseMultilinearExtension::from_evaluations_vec(r.len(), evals);
 
@@ -450,7 +442,7 @@ pub fn build_eq_x_r<I: CryptoInteger>(
 ///      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
 /// over r, which is
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
-pub fn build_eq_x_r_vec<I: CryptoInteger>(r: &[I]) -> Result<Vec<I>, ArithErrors> {
+pub fn build_eq_x_r_vec<I: Integer>(r: &[I]) -> Result<Vec<I>, ArithErrors> {
     // we build eq(x,r) from its evaluations
     // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars
     // for example, with num_vars = 4, x is a binary vector of 4, then
@@ -471,7 +463,7 @@ pub fn build_eq_x_r_vec<I: CryptoInteger>(r: &[I]) -> Result<Vec<I>, ArithErrors
 /// A helper function to build eq(x, r) recursively.
 /// This function takes `r.len()` steps, and for each step it requires a maximum
 /// `r.len()-1` multiplications.
-fn build_eq_x_r_helper<I: CryptoInteger>(r: &[I], buf: &mut Vec<I>) -> Result<(), ArithErrors> {
+fn build_eq_x_r_helper<I: Integer>(r: &[I], buf: &mut Vec<I>) -> Result<(), ArithErrors> {
     if r.is_empty() {
         return Err(ArithErrors::InvalidParameters("r length is 0".into()));
     } else if r.len() == 1 {

--- a/src/poly_z/mle/mod.rs
+++ b/src/poly_z/mle/mod.rs
@@ -16,7 +16,7 @@ use ark_std::{
 ///
 /// Index represents a point, which is a vector in {0,1}^`num_vars` in little
 /// endian form. For example, `0b1011` represents `P(1,1,0,1)`
-pub trait MultilinearExtension<I: CryptoInteger>:
+pub trait MultilinearExtension<I: Integer>:
     Sized
     + Clone
     + Debug
@@ -71,4 +71,4 @@ pub use dense::build_eq_x_r;
 pub use dense::DenseMultilinearExtension;
 pub use sparse::SparseMultilinearExtension;
 
-use crate::traits::CryptoInteger;
+use crate::traits::Integer;

--- a/src/poly_z/mle/sparse.rs
+++ b/src/poly_z/mle/sparse.rs
@@ -14,7 +14,7 @@ use num_traits::Zero;
 use rayon::iter::*;
 
 use super::{swap_bits, MultilinearExtension};
-use crate::{sparse_matrix::SparseMatrix, traits::CryptoInteger};
+use crate::{sparse_matrix::SparseMatrix, traits::Integer};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SparseMultilinearExtension<I> {
@@ -25,7 +25,7 @@ pub struct SparseMultilinearExtension<I> {
     zero: I,
 }
 
-impl<I: CryptoInteger> SparseMultilinearExtension<I> {
+impl<I: Integer> SparseMultilinearExtension<I> {
     pub fn from_evaluations<'a>(
         num_vars: usize,
         evaluations: impl IntoIterator<Item = &'a (usize, I)>,
@@ -126,7 +126,7 @@ impl<I: CryptoInteger> SparseMultilinearExtension<I> {
     }
 }
 
-impl<I: CryptoInteger> MultilinearExtension<I> for SparseMultilinearExtension<I> {
+impl<I: Integer> MultilinearExtension<I> for SparseMultilinearExtension<I> {
     fn num_vars(&self) -> usize {
         self.num_vars
     }
@@ -217,7 +217,7 @@ impl<I: CryptoInteger> MultilinearExtension<I> for SparseMultilinearExtension<I>
         evaluations
     }
 }
-impl<I: CryptoInteger> Zero for SparseMultilinearExtension<I> {
+impl<I: Integer> Zero for SparseMultilinearExtension<I> {
     fn zero() -> Self {
         Self {
             num_vars: 0,
@@ -230,16 +230,14 @@ impl<I: CryptoInteger> Zero for SparseMultilinearExtension<I> {
         self.num_vars == 0 && self.evaluations.is_empty()
     }
 }
-impl<I: CryptoInteger> Add for SparseMultilinearExtension<I> {
+impl<I: Integer> Add for SparseMultilinearExtension<I> {
     type Output = SparseMultilinearExtension<I>;
 
     fn add(self, other: SparseMultilinearExtension<I>) -> Self {
         &self + &other
     }
 }
-impl<'a, I: CryptoInteger> Add<&'a SparseMultilinearExtension<I>>
-    for &SparseMultilinearExtension<I>
-{
+impl<'a, I: Integer> Add<&'a SparseMultilinearExtension<I>> for &SparseMultilinearExtension<I> {
     type Output = SparseMultilinearExtension<I>;
 
     fn add(self, rhs: &'a SparseMultilinearExtension<I>) -> Self::Output {
@@ -274,21 +272,19 @@ impl<'a, I: CryptoInteger> Add<&'a SparseMultilinearExtension<I>>
     }
 }
 
-impl<I: CryptoInteger> AddAssign for SparseMultilinearExtension<I> {
+impl<I: Integer> AddAssign for SparseMultilinearExtension<I> {
     fn add_assign(&mut self, other: Self) {
         *self = &*self + &other;
     }
 }
-impl<'a, I: CryptoInteger> AddAssign<&'a SparseMultilinearExtension<I>>
+impl<'a, I: Integer> AddAssign<&'a SparseMultilinearExtension<I>>
     for SparseMultilinearExtension<I>
 {
     fn add_assign(&mut self, rhs: &'a SparseMultilinearExtension<I>) {
         *self = &*self + rhs;
     }
 }
-impl<I: CryptoInteger> AddAssign<(I, &SparseMultilinearExtension<I>)>
-    for SparseMultilinearExtension<I>
-{
+impl<I: Integer> AddAssign<(I, &SparseMultilinearExtension<I>)> for SparseMultilinearExtension<I> {
     fn add_assign(&mut self, (r, other): (I, &SparseMultilinearExtension<I>)) {
         if !self.is_zero() && !other.is_zero() {
             assert_eq!(
@@ -307,7 +303,7 @@ impl<I: CryptoInteger> AddAssign<(I, &SparseMultilinearExtension<I>)>
         *self += &other;
     }
 }
-impl<I: CryptoInteger> Neg for SparseMultilinearExtension<I> {
+impl<I: Integer> Neg for SparseMultilinearExtension<I> {
     type Output = SparseMultilinearExtension<I>;
 
     fn neg(self) -> Self {
@@ -321,16 +317,14 @@ impl<I: CryptoInteger> Neg for SparseMultilinearExtension<I> {
         }
     }
 }
-impl<I: CryptoInteger> Sub for SparseMultilinearExtension<I> {
+impl<I: Integer> Sub for SparseMultilinearExtension<I> {
     type Output = SparseMultilinearExtension<I>;
 
     fn sub(self, other: SparseMultilinearExtension<I>) -> Self {
         &self - &other
     }
 }
-impl<'a, I: CryptoInteger> Sub<&'a SparseMultilinearExtension<I>>
-    for &SparseMultilinearExtension<I>
-{
+impl<'a, I: Integer> Sub<&'a SparseMultilinearExtension<I>> for &SparseMultilinearExtension<I> {
     type Output = SparseMultilinearExtension<I>;
 
     #[allow(clippy::suspicious_arithmetic_impl)]
@@ -338,19 +332,19 @@ impl<'a, I: CryptoInteger> Sub<&'a SparseMultilinearExtension<I>>
         self + &rhs.clone().neg()
     }
 }
-impl<I: CryptoInteger> SubAssign for SparseMultilinearExtension<I> {
+impl<I: Integer> SubAssign for SparseMultilinearExtension<I> {
     fn sub_assign(&mut self, other: SparseMultilinearExtension<I>) {
         *self = &*self - &other;
     }
 }
-impl<'a, I: CryptoInteger> SubAssign<&'a SparseMultilinearExtension<I>>
+impl<'a, I: Integer> SubAssign<&'a SparseMultilinearExtension<I>>
     for SparseMultilinearExtension<I>
 {
     fn sub_assign(&mut self, rhs: &'a SparseMultilinearExtension<I>) {
         *self = &*self - rhs;
     }
 }
-impl<I: CryptoInteger> Index<usize> for SparseMultilinearExtension<I> {
+impl<I: Integer> Index<usize> for SparseMultilinearExtension<I> {
     type Output = I;
 
     /// Returns the evaluation of the polynomial at a point represented by
@@ -367,19 +361,19 @@ impl<I: CryptoInteger> Index<usize> for SparseMultilinearExtension<I> {
 }
 
 /// Utilities
-fn tuples_to_treemap<I: CryptoInteger>(tuples: &[(usize, I)]) -> BTreeMap<usize, I> {
+fn tuples_to_treemap<I: Integer>(tuples: &[(usize, I)]) -> BTreeMap<usize, I> {
     BTreeMap::from_iter(tuples.iter().map(|(i, v)| (*i, v.clone())))
 }
 
-fn treemap_to_hashmap<I: CryptoInteger>(map: &BTreeMap<usize, I>) -> HashMap<usize, I> {
+fn treemap_to_hashmap<I: Integer>(map: &BTreeMap<usize, I>) -> HashMap<usize, I> {
     HashMap::from_iter(map.iter().map(|(i, v)| (*i, v.clone())))
 }
-fn hashmap_to_treemap<I: CryptoInteger>(map: &HashMap<usize, I>) -> BTreeMap<usize, I> {
+fn hashmap_to_treemap<I: Integer>(map: &HashMap<usize, I>) -> BTreeMap<usize, I> {
     BTreeMap::from_iter(map.iter().map(|(i, v)| (*i, v.clone())))
 }
 
 // precompute  f(x) = eq(g,x)
-fn precompute_eq<I: CryptoInteger>(g: &[I]) -> Vec<I> {
+fn precompute_eq<I: Integer>(g: &[I]) -> Vec<I> {
     let dim = g.len();
     let mut dp = vec![I::ZERO; 1 << dim];
     dp[0] = I::one() - &g[0];
@@ -400,10 +394,10 @@ mod tests {
     use num_traits::ConstZero;
 
     use super::*;
-    use crate::crypto_int::CryptoInt;
+    use crate::crypto_int::Int;
 
     // Function to convert usize to a binary vector of Ring elements.
-    fn usize_to_binary_vector<I: CryptoInteger>(n: usize, dimensions: usize) -> Vec<I> {
+    fn usize_to_binary_vector<I: Integer>(n: usize, dimensions: usize) -> Vec<I> {
         let mut bits = Vec::with_capacity(dimensions);
         let mut current = n;
 
@@ -419,14 +413,14 @@ mod tests {
     }
 
     // Wrapper function to generate a boolean hypercube.
-    fn boolean_hypercube<const N: usize>(dimensions: usize) -> Vec<Vec<CryptoInt<N>>> {
+    fn boolean_hypercube<const N: usize>(dimensions: usize) -> Vec<Vec<Int<N>>> {
         let max_val = 1 << dimensions; // 2^dimensions
         (0..max_val)
             .map(|i| usize_to_binary_vector(i, dimensions))
             .collect()
     }
 
-    fn get_test_z<const N: usize>(input: i64) -> Vec<CryptoInt<N>> {
+    fn get_test_z<const N: usize>(input: i64) -> Vec<Int<N>> {
         [
             input, // io
             1,
@@ -437,10 +431,10 @@ mod tests {
         ]
         .iter()
         .cloned()
-        .map(CryptoInt::from)
+        .map(Int::from)
         .collect()
     }
-    fn matrix_cast<const N: usize>(m: &[Vec<usize>]) -> SparseMatrix<CryptoInt<N>> {
+    fn matrix_cast<const N: usize>(m: &[Vec<usize>]) -> SparseMatrix<Int<N>> {
         let n_rows = m.len();
         let n_cols = m[0].len();
         let mut coeffs = Vec::with_capacity(n_rows);
@@ -448,7 +442,7 @@ mod tests {
             let mut row_coeffs = Vec::with_capacity(n_cols);
             for (col_i, &val) in row.iter().enumerate() {
                 if val != 0 {
-                    row_coeffs.push((CryptoInt::from(val as i64), col_i));
+                    row_coeffs.push((Int::from(val as i64), col_i));
                 }
             }
             coeffs.push(row_coeffs);
@@ -501,7 +495,7 @@ mod tests {
         }
         // for the rest of elements of the boolean hypercube, expect it to evaluate to zero
         for s_i in bhc.iter().take(1 << z_mle.num_vars).skip(z.len()) {
-            assert_eq!(z_mle.fixed_variables(s_i,)[0], CryptoInt::<N>::ZERO);
+            assert_eq!(z_mle.fixed_variables(s_i,)[0], Int::<N>::ZERO);
         }
     }
 }

--- a/src/poly_z/polynomials/multilinear_polynomial.rs
+++ b/src/poly_z/polynomials/multilinear_polynomial.rs
@@ -8,14 +8,14 @@ use ark_std::{end_timer, rand::RngCore, start_timer, vec, vec::Vec};
 pub use crate::poly_z::mle::{DenseMultilinearExtension, MultilinearExtension};
 use crate::{
     poly::{get_batched_nv, ArithErrors, RefCounter},
-    traits::CryptoInteger,
+    traits::Integer,
 };
 
 /// Sample a random list of multilinear polynomials.
 /// Returns
 /// - the list of polynomials,
 /// - its sum of polynomial evaluations over the boolean hypercube.
-pub fn random_mle_list<Rn: RngCore, I: CryptoInteger>(
+pub fn random_mle_list<Rn: RngCore, I: Integer>(
     nv: usize,
     degree: usize,
     rng: &mut Rn,
@@ -48,7 +48,7 @@ pub fn random_mle_list<Rn: RngCore, I: CryptoInteger>(
 }
 
 // Build a randomize list of mle-s whose sum is zero.
-pub fn random_zero_mle_list<I: CryptoInteger, Rn: RngCore>(
+pub fn random_zero_mle_list<I: Integer, Rn: RngCore>(
     nv: usize,
     degree: usize,
     rng: &mut Rn,
@@ -81,7 +81,7 @@ pub fn identity_permutation(num_vars: usize, num_chunks: usize) -> Vec<i64> {
 }
 
 /// A list of MLEs that represents an identity permutation
-pub fn identity_permutation_mles<I: CryptoInteger>(
+pub fn identity_permutation_mles<I: Integer>(
     num_vars: usize,
     num_chunks: usize,
 ) -> Vec<RefCounter<DenseMultilinearExtension<I>>> {
@@ -98,7 +98,7 @@ pub fn identity_permutation_mles<I: CryptoInteger>(
     res
 }
 
-pub fn random_permutation<Rn: RngCore, I: CryptoInteger>(
+pub fn random_permutation<Rn: RngCore, I: Integer>(
     num_vars: usize,
     num_chunks: usize,
     rng: &mut Rn,
@@ -114,7 +114,7 @@ pub fn random_permutation<Rn: RngCore, I: CryptoInteger>(
 }
 
 /// A list of MLEs that represent a random permutation
-pub fn random_permutation_mles<Rn: RngCore, I: CryptoInteger>(
+pub fn random_permutation_mles<Rn: RngCore, I: Integer>(
     num_vars: usize,
     num_chunks: usize,
     rng: &mut Rn,
@@ -133,12 +133,12 @@ pub fn random_permutation_mles<Rn: RngCore, I: CryptoInteger>(
     res
 }
 
-pub fn evaluate_opt<I: CryptoInteger>(poly: &DenseMultilinearExtension<I>, point: &[I]) -> I {
+pub fn evaluate_opt<I: Integer>(poly: &DenseMultilinearExtension<I>, point: &[I]) -> I {
     assert_eq!(poly.num_vars, point.len());
     fix_variables(poly, point).evaluations[0].clone()
 }
 
-pub fn fix_variables<I: CryptoInteger>(
+pub fn fix_variables<I: Integer>(
     poly: &DenseMultilinearExtension<I>,
     partial_point: &[I],
 ) -> DenseMultilinearExtension<I> {
@@ -157,7 +157,7 @@ pub fn fix_variables<I: CryptoInteger>(
     DenseMultilinearExtension::from_evaluations_slice(nv - dim, &poly[..1 << (nv - dim)])
 }
 
-fn fix_one_variable_helper<I: CryptoInteger>(data: &[I], nv: usize, point: &I) -> Vec<I> {
+fn fix_one_variable_helper<I: Integer>(data: &[I], nv: usize, point: &I) -> Vec<I> {
     let mut res = vec![I::ZERO; 1 << (nv - 1)];
 
     // evaluate single variable of partial point from left to right
@@ -169,12 +169,12 @@ fn fix_one_variable_helper<I: CryptoInteger>(data: &[I], nv: usize, point: &I) -
     res
 }
 
-pub fn evaluate_no_par<I: CryptoInteger>(poly: &DenseMultilinearExtension<I>, point: &[I]) -> I {
+pub fn evaluate_no_par<I: Integer>(poly: &DenseMultilinearExtension<I>, point: &[I]) -> I {
     assert_eq!(poly.num_vars, point.len());
     fix_variables_no_par(poly, point).evaluations[0].clone()
 }
 
-fn fix_variables_no_par<I: CryptoInteger>(
+fn fix_variables_no_par<I: Integer>(
     poly: &DenseMultilinearExtension<I>,
     partial_point: &[I],
 ) -> DenseMultilinearExtension<I> {
@@ -197,7 +197,7 @@ fn fix_variables_no_par<I: CryptoInteger>(
 
 /// merge a set of polynomials. Returns an error if the
 /// polynomials do not share a same number of nvs.
-pub fn merge_polynomials<I: CryptoInteger>(
+pub fn merge_polynomials<I: Integer>(
     polynomials: &[RefCounter<DenseMultilinearExtension<I>>],
 ) -> Result<RefCounter<DenseMultilinearExtension<I>>, ArithErrors> {
     let nv = polynomials[0].num_vars();
@@ -220,7 +220,7 @@ pub fn merge_polynomials<I: CryptoInteger>(
     ))
 }
 
-pub fn fix_last_variables_no_par<I: CryptoInteger>(
+pub fn fix_last_variables_no_par<I: Integer>(
     poly: &DenseMultilinearExtension<I>,
     partial_point: &[I],
 ) -> DenseMultilinearExtension<I> {
@@ -231,7 +231,7 @@ pub fn fix_last_variables_no_par<I: CryptoInteger>(
     res
 }
 
-fn fix_last_variable_no_par<I: CryptoInteger>(
+fn fix_last_variable_no_par<I: Integer>(
     poly: &DenseMultilinearExtension<I>,
     partial_point: &I,
 ) -> DenseMultilinearExtension<I> {
@@ -245,7 +245,7 @@ fn fix_last_variable_no_par<I: CryptoInteger>(
     }
     DenseMultilinearExtension::from_evaluations_vec(nv - 1, res)
 }
-pub fn fix_last_variables<I: CryptoInteger>(
+pub fn fix_last_variables<I: Integer>(
     poly: &DenseMultilinearExtension<I>,
     partial_point: &[I],
 ) -> DenseMultilinearExtension<I> {
@@ -264,7 +264,7 @@ pub fn fix_last_variables<I: CryptoInteger>(
     DenseMultilinearExtension::from_evaluations_slice(nv - dim, &poly[..1 << (nv - dim)])
 }
 
-fn fix_last_variable_helper<I: CryptoInteger>(data: &[I], nv: usize, point: &I) -> Vec<I> {
+fn fix_last_variable_helper<I: Integer>(data: &[I], nv: usize, point: &I) -> Vec<I> {
     let half_len = 1 << (nv - 1);
     let mut res = vec![I::ZERO; half_len];
 

--- a/src/prime_gen/mod.rs
+++ b/src/prime_gen/mod.rs
@@ -1,32 +1,30 @@
 use num_traits::One;
 
 use crate::{
-    traits::{types::PrimalityTest, CryptoUinteger, Field, FromBytes, Integer, Words},
+    traits::{types::PrimalityTest, BigInteger, Field, FromBytes, Uinteger, Words},
     transcript::KeccakTranscript,
 };
 
-fn hash_int<F: Field>(hasher: &mut KeccakTranscript) -> F::CryptoUint {
+fn hash_int<F: Field>(hasher: &mut KeccakTranscript) -> F::U {
     let n_bytes = F::W::num_words() * 8;
     let bytes = hasher.get_random_bytes(n_bytes);
     hasher.absorb(&bytes);
-    F::CryptoUint::from_bytes_be(&bytes).expect("Failed to convert bytes to CryptoUint")
+    F::U::from_bytes_be(&bytes).expect("Failed to convert bytes to CryptoUint")
 }
 
-pub fn get_prime<F: Field>(hasher: &mut KeccakTranscript) -> F::I {
+pub fn get_prime<F: Field>(hasher: &mut KeccakTranscript) -> F::B {
     let prime = loop {
-        let mut prime_candidate: F::CryptoUint = hash_int::<F>(hasher);
+        let mut prime_candidate: F::U = hash_int::<F>(hasher);
         if prime_candidate.is_even() {
-            prime_candidate -= &F::CryptoUint::one();
+            prime_candidate -= &F::U::one();
         }
-        let mr = <<F as Field>::CryptoUint as CryptoUinteger>::PrimalityTest::new(
-            prime_candidate.clone(),
-        );
+        let mr = <<F as Field>::U as Uinteger>::PrimalityTest::new(prime_candidate.clone());
 
         if mr.is_probably_prime() {
             break prime_candidate;
         }
     };
-    F::I::new(prime.to_words())
+    F::B::new(prime.to_words())
 }
 
 #[cfg(test)]

--- a/src/sparse_matrix.rs
+++ b/src/sparse_matrix.rs
@@ -41,7 +41,7 @@ where
     <T as FieldMap<F>>::Output: Clone + Send + Sync,
 {
     type Output = SparseMatrix<T::Output>;
-    fn map_to_field(&self, config_ref: F::Cr) -> Self::Output {
+    fn map_to_field(&self, config_ref: F::R) -> Self::Output {
         let mut matrix = SparseMatrix::<F> {
             n_rows: self.n_rows,
             n_cols: self.n_cols,
@@ -167,7 +167,7 @@ pub fn compute_eval_table_sparse<F: Field>(
     rx: &[F],
     num_rows: usize,
     num_cols: usize,
-    config: F::Cr,
+    config: F::R,
 ) -> Vec<F> {
     assert_eq!(rx.len(), num_rows);
     M.coeffs.iter().enumerate().fold(

--- a/src/sumcheck.rs
+++ b/src/sumcheck.rs
@@ -54,7 +54,7 @@ impl<F: Field> MLSumcheck<F> {
         nvars: usize,
         degree: usize,
         comb_fn: impl Fn(&[F]) -> F + Send + Sync,
-        config: F::Cr,
+        config: F::R,
     ) -> (SumcheckProof<F>, ProverState<F>) {
         let (nvars_field, degree_field): (F, F) = if F::W::num_words() == 1 {
             (
@@ -98,7 +98,7 @@ impl<F: Field> MLSumcheck<F> {
         degree: usize,
         claimed_sum: F,
         proof: &SumcheckProof<F>,
-        config: F::Cr,
+        config: F::R,
     ) -> Result<SubClaim<F>, SumCheckError<F>> {
         let (nvars_field, degree_field): (F, F) = if F::W::num_words() == 1 {
             (
@@ -147,7 +147,7 @@ mod tests {
     fn generate_sumcheck_proof<F: Field>(
         nvars: usize,
         mut rng: &mut (impl Rng + Sized),
-        config: F::Cr,
+        config: F::R,
     ) -> (usize, F, SumcheckProof<F>) {
         let mut transcript = KeccakTranscript::default();
 

--- a/src/sumcheck/prover.rs
+++ b/src/sumcheck/prover.rs
@@ -63,7 +63,7 @@ impl<F: Field> IPForMLSumcheck<F> {
         prover_state: &mut ProverState<F>,
         v_msg: &Option<VerifierMsg<F>>,
         comb_fn: impl Fn(&[F]) -> F + Send + Sync,
-        config: F::Cr,
+        config: F::R,
     ) -> ProverMsg<F> {
         if let Some(msg) = v_msg {
             if prover_state.round == 0 {
@@ -79,7 +79,7 @@ impl<F: Field> IPForMLSumcheck<F> {
                 AtomicPtr::new(config.pointer().expect("FieldConfig cannot be null"));
             cfg_iter_mut!(prover_state.mles).for_each(|multiplicand| {
                 multiplicand.fix_variables(&[r.clone()], unsafe {
-                    F::Cr::new(atomic_config.load(atomic::Ordering::Relaxed))
+                    F::R::new(atomic_config.load(atomic::Ordering::Relaxed))
                 });
             });
         } else if prover_state.round > 0 {

--- a/src/sumcheck/utils.rs
+++ b/src/sumcheck/utils.rs
@@ -28,7 +28,7 @@ pub fn rand_poly<F: Field>(
     nv: usize,
     num_multiplicands_range: (usize, usize),
     num_products: usize,
-    config: F::Cr,
+    config: F::R,
     rng: &mut impl RngCore,
 ) -> Result<
     (
@@ -65,7 +65,7 @@ pub fn rand_poly<F: Field>(
     Ok(((mles, degree), products, sum))
 }
 
-pub fn rand_poly_comb_fn<F: Field>(vals: &[F], products: &[(F, Vec<usize>)], config: F::Cr) -> F {
+pub fn rand_poly_comb_fn<F: Field>(vals: &[F], products: &[(F, Vec<usize>)], config: F::R) -> F {
     let mut result = 0u64.map_to_field(config);
     for (coef, indices) in products {
         let mut term = coef.clone();
@@ -103,7 +103,7 @@ pub fn eq_eval<F: Field>(x: &[F], y: &[F]) -> Result<F, ArithErrors> {
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
 pub fn build_eq_x_r<F: Field>(
     r: &[F],
-    config: F::Cr,
+    config: F::R,
 ) -> Result<DenseMultilinearExtension<F>, ArithErrors> {
     let evals = build_eq_x_r_vec(r)?;
     let mle = DenseMultilinearExtension::from_evaluations_vec(r.len(), evals, config);

--- a/src/sumcheck/verifier.rs
+++ b/src/sumcheck/verifier.rs
@@ -27,7 +27,7 @@ pub struct VerifierState<F: Field> {
     /// a list storing the randomness sampled by the verifier at each round
     randomness: Vec<F>,
     /// The configuration of the field that the sumcheck protocol is working in
-    config: F::Cr,
+    config: F::R,
 }
 
 /// Subclaim when verifier is convinced
@@ -41,7 +41,7 @@ pub struct SubClaim<F> {
 
 impl<F: Field> IPForMLSumcheck<F> {
     /// initialize the verifier
-    pub fn verifier_init(nvars: usize, degree: usize, config: F::Cr) -> VerifierState<F> {
+    pub fn verifier_init(nvars: usize, degree: usize, config: F::R) -> VerifierState<F> {
         VerifierState {
             round: 1,
             nv: nvars,
@@ -97,7 +97,7 @@ impl<F: Field> IPForMLSumcheck<F> {
     pub fn check_and_generate_subclaim(
         verifier_state: VerifierState<F>,
         asserted_sum: F,
-        config: F::Cr,
+        config: F::R,
     ) -> Result<SubClaim<F>, SumCheckError<F>> {
         if !verifier_state.finished {
             panic!("Verifier has not finished.");
@@ -136,7 +136,7 @@ impl<F: Field> IPForMLSumcheck<F> {
     /// Given the same calling context, `transcript_round` output exactly the same message as
     /// `verify_round`
     #[inline]
-    pub fn sample_round(transcript: &mut Transcript, config: F::Cr) -> VerifierMsg<F> {
+    pub fn sample_round(transcript: &mut Transcript, config: F::R) -> VerifierMsg<F> {
         VerifierMsg {
             randomness: transcript.get_challenge(config),
         }
@@ -147,7 +147,7 @@ impl<F: Field> IPForMLSumcheck<F> {
 /// p_i.len()-1 passing through the y-values in p_i at x = 0,..., p_i.len()-1
 /// and evaluate this  polynomial at `eval_at`. In other words, efficiently compute
 ///  \sum_{i=0}^{len p_i - 1} p_i[i] * (\prod_{j!=i} (eval_at - j)/(i-j))
-pub(crate) fn interpolate_uni_poly<F: Field>(p_i: &[F], x: F, config: F::Cr) -> F {
+pub(crate) fn interpolate_uni_poly<F: Field>(p_i: &[F], x: F, config: F::R) -> F {
     // We will need these a few times
     let zero: F = 0u64.map_to_field(config);
     let one = 1u64.map_to_field(config);
@@ -293,7 +293,7 @@ pub(crate) fn interpolate_uni_poly<F: Field>(p_i: &[F], x: F, config: F::Cr) -> 
 
 /// compute the factorial(a) = 1 * 2 * ... * a
 #[inline]
-fn field_factorial<F: Field>(a: usize, config: F::Cr) -> F {
+fn field_factorial<F: Field>(a: usize, config: F::R) -> F {
     let mut res: F = F::one();
     for i in 1..=(a as u64) {
         res *= <u64 as FieldMap<F>>::map_to_field(&i, config);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,4 +2,4 @@ pub(crate) mod conversion;
 pub(crate) mod types;
 
 pub use conversion::{FieldMap, FromBytes};
-pub use types::{Config, ConfigReference, CryptoInteger, CryptoUinteger, Field, Integer, Words};
+pub use types::{BigInteger, Config, ConfigReference, Field, Integer, Uinteger, Words};

--- a/src/traits/conversion.rs
+++ b/src/traits/conversion.rs
@@ -11,5 +11,5 @@ pub trait FromBytes: Sized {
 
 pub trait FieldMap<F: Field> {
     type Output;
-    fn map_to_field(&self, config_ref: F::Cr) -> Self::Output;
+    fn map_to_field(&self, config_ref: F::R) -> Self::Output;
 }

--- a/src/traits/types.rs
+++ b/src/traits/types.rs
@@ -41,37 +41,37 @@ pub trait Field:
     + for<'a> MulAssign<&'a Self>
 {
     /// Integer representation type for the field element.
-    type I: Integer<W = Self::W> + From<Self::CryptoInt> + FieldMap<Self, Output = Self>;
+    type B: BigInteger<W = Self::W> + From<Self::I> + FieldMap<Self, Output = Self>;
     /// Field configuration type.
-    type C: Config<I = Self::I>;
+    type C: Config<I = Self::B>;
     /// Reference to field configuration.
-    type Cr: ConfigReference<C = Self::C>;
+    type R: ConfigReference<C = Self::C>;
     /// Word representation type.
     type W: Words;
     /// Cryptographic integer type.
-    type CryptoInt: CryptoInteger<W = Self::W, Uint = Self::CryptoUint> + for<'a> From<&'a Self::I>;
+    type I: Integer<W = Self::W, Uint = Self::U> + for<'a> From<&'a Self::B>;
     /// Cryptographic unsigned integer type.
-    type CryptoUint: CryptoUinteger<W = Self::W, Int = Self::CryptoInt>;
+    type U: Uinteger<W = Self::W, Int = Self::I>;
     /// Debug representation for the field.
     type DebugField: Debug + From<Self> + Send + Sync;
     /// Creates a new field element from config and value, without checking.
-    fn new_unchecked(config: Self::Cr, value: Self::I) -> Self;
+    fn new_unchecked(config: Self::R, value: Self::B) -> Self;
     /// Creates a new field element from value, without config.
-    fn without_config(value: Self::I) -> Self;
+    fn without_config(value: Self::B) -> Self;
     /// Generates a random field element with the given config.
-    fn rand_with_config<R: ark_std::rand::Rng + ?Sized>(rng: &mut R, config: Self::Cr) -> Self;
+    fn rand_with_config<R: ark_std::rand::Rng + ?Sized>(rng: &mut R, config: Self::R) -> Self;
     /// Sets the field configuration.
-    fn set_config(&mut self, config: Self::Cr);
+    fn set_config(&mut self, config: Self::R);
     /// Returns a reference to the integer value.
-    fn value(&self) -> &Self::I;
+    fn value(&self) -> &Self::B;
     /// Returns a mutable reference to the integer value.
-    fn value_mut(&mut self) -> &mut Self::I;
+    fn value_mut(&mut self) -> &mut Self::B;
     /// Absorbs the field element into a Keccak transcript.
     fn absorb_into_transcript(&self, transcript: &mut KeccakTranscript);
 }
 
 /// Trait for integer types used as field element representations.
-pub trait Integer: From<u64> + From<u32> + Debug + FromBytes + Copy {
+pub trait BigInteger: From<u64> + From<u32> + Debug + FromBytes + Copy {
     type W: Words;
     /// Converts the integer to its word representation.
     fn to_words(&self) -> Self::W;
@@ -93,7 +93,7 @@ pub trait Integer: From<u64> + From<u32> + Debug + FromBytes + Copy {
 
 /// Trait for field configuration types.
 pub trait Config: PartialEq + Eq {
-    type I: Integer;
+    type I: BigInteger;
     /// Returns the modulus for the field.
     fn modulus(&self) -> &Self::I;
     /// Multiplies two integers in the field.
@@ -134,7 +134,7 @@ pub trait Words:
 }
 
 /// Trait for cryptographic integer types.
-pub trait CryptoInteger:
+pub trait Integer:
     Zero
     + ConstZero
     + One
@@ -164,8 +164,8 @@ pub trait CryptoInteger:
     + ToBytes
 {
     type W: Words;
-    type Uint: CryptoUinteger<W = Self::W>;
-    type I: Integer<W = Self::W> + for<'a> From<&'a Self>;
+    type Uint: Uinteger<W = Self::W>;
+    type I: BigInteger<W = Self::W> + for<'a> From<&'a Self>;
     /// Constructs from words.
     fn from_words(words: Self::W) -> Self;
     fn as_words(&self) -> &[u64];
@@ -174,9 +174,9 @@ pub trait CryptoInteger:
 }
 
 /// Trait for cryptographic unsigned integer types.
-pub trait CryptoUinteger: Clone + FromBytes + One + for<'a> SubAssign<&'a Self> {
+pub trait Uinteger: Clone + FromBytes + One + for<'a> SubAssign<&'a Self> {
     type W: Words;
-    type Int: CryptoInteger<W = Self::W>;
+    type Int: Integer<W = Self::W>;
     type PrimalityTest: PrimalityTest<Self>;
     /// Constructs from words.
     fn from_words(words: Self::W) -> Self;
@@ -187,7 +187,7 @@ pub trait CryptoUinteger: Clone + FromBytes + One + for<'a> SubAssign<&'a Self> 
     fn is_even(&self) -> bool;
 }
 
-pub trait PrimalityTest<U: CryptoUinteger> {
+pub trait PrimalityTest<U: Uinteger> {
     type Inner;
     fn new(candidate: U) -> Self;
     fn is_probably_prime(&self) -> bool;

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -2,7 +2,7 @@ use ark_std::vec::Vec;
 use sha3::{Digest, Keccak256};
 
 use crate::{
-    traits::{Config, ConfigReference, CryptoInteger, Field, FieldMap, Integer, Words},
+    traits::{BigInteger, Config, ConfigReference, Field, FieldMap, Integer, Words},
     zip::pcs::structs::ZipTranscript,
 };
 
@@ -68,7 +68,7 @@ impl KeccakTranscript {
     }
 
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn get_challenge<F: Field>(&mut self, config_ref: F::Cr) -> F {
+    pub fn get_challenge<F: Field>(&mut self, config_ref: F::R) -> F {
         let (lo, hi) = self.get_challenge_limbs();
         let config = config_ref.reference().expect("Field config cannot be none");
         let modulus = config.modulus();
@@ -91,7 +91,7 @@ impl KeccakTranscript {
             challenge.set_config(config_ref);
             challenge
         } else if challenge_num_bits >= 256 {
-            let two_to_128 = F::I::from_bits_le(&(0..196).map(|i| i == 128).collect::<Vec<bool>>())
+            let two_to_128 = F::B::from_bits_le(&(0..196).map(|i| i == 128).collect::<Vec<bool>>())
                 .map_to_field(config_ref);
 
             let mut challenge: F = <u128 as FieldMap<F>>::map_to_field(&lo, config_ref)
@@ -104,7 +104,7 @@ impl KeccakTranscript {
 
             let truncated_hi = hi & hi_mask;
 
-            let two_to_128 = F::I::from_bits_le(&(0..196).map(|i| i == 128).collect::<Vec<bool>>())
+            let two_to_128 = F::B::from_bits_le(&(0..196).map(|i| i == 128).collect::<Vec<bool>>())
                 .map_to_field(config_ref);
 
             let mut ret: F = <u128 as FieldMap<F>>::map_to_field(&lo, config_ref)
@@ -113,13 +113,13 @@ impl KeccakTranscript {
             ret
         }
     }
-    pub fn get_challenges<F: Field>(&mut self, n: usize, config: F::Cr) -> Vec<F> {
+    pub fn get_challenges<F: Field>(&mut self, n: usize, config: F::R) -> Vec<F> {
         let mut challenges = Vec::with_capacity(n);
         challenges.extend((0..n).map(|_| self.get_challenge::<F>(config)));
         challenges
     }
 
-    pub fn get_integer_challenge<I: CryptoInteger>(&mut self) -> I {
+    pub fn get_integer_challenge<I: Integer>(&mut self) -> I {
         let mut words = I::W::default();
 
         for i in 0..I::W::num_words() {
@@ -134,7 +134,7 @@ impl KeccakTranscript {
         I::from_words(words)
     }
 
-    pub fn get_integer_challenges<I: CryptoInteger>(&mut self, n: usize) -> Vec<I> {
+    pub fn get_integer_challenges<I: Integer>(&mut self, n: usize) -> Vec<I> {
         (0..n).map(|_| self.get_integer_challenge()).collect()
     }
     fn get_usize_in_range(&mut self, range: &ark_std::ops::Range<usize>) -> usize {
@@ -148,7 +148,7 @@ impl KeccakTranscript {
         range.start + (num % (range.end - range.start))
     }
 }
-impl<I: CryptoInteger> ZipTranscript<I> for KeccakTranscript {
+impl<I: Integer> ZipTranscript<I> for KeccakTranscript {
     fn get_encoding_element(&mut self) -> I {
         let byte = self.get_random_bytes(1)[0];
         // cancels all bits and depends only on whether the random byte LSB is 0 or 1

--- a/src/zinc/prover.rs
+++ b/src/zinc/prover.rs
@@ -17,7 +17,7 @@ use crate::{
     poly_z::mle::DenseMultilinearExtension as DenseMultilinearExtensionZ,
     sparse_matrix::SparseMatrix,
     sumcheck::{utils::build_eq_x_r, MLSumcheck, SumcheckProof},
-    traits::{ConfigReference, CryptoInteger, Field, FieldMap},
+    traits::{ConfigReference, Field, FieldMap, Integer},
     transcript::KeccakTranscript,
     zip::{
         code::ZipSpec,
@@ -32,27 +32,27 @@ use crate::{
 pub type SpartanResult<T, F> = Result<T, SpartanError<F>>;
 pub type ZincResult<T, F> = Result<T, ZincError<F>>;
 
-pub trait Prover<I: CryptoInteger, F: Field> {
+pub trait Prover<I: Integer, F: Field> {
     fn prove<I2, I4, I8>(
         &self,
         statement: &Statement_Z<I>,
         wit: &Witness_Z<I>,
         transcript: &mut KeccakTranscript,
         ccs: &CCS_Z<I>,
-        config: F::Cr,
+        config: F::R,
     ) -> Result<ZincProof<I, F>, ZincError<F>>
     where
-        I8: CryptoInteger + for<'a> From<&'a I> + for<'a> From<&'a I2>,
-        I4: CryptoInteger + for<'a> From<&'a I> + for<'a> From<&'a I2> + ToBytes,
-        I2: CryptoInteger + for<'a> From<&'a I>,
+        I8: Integer + for<'a> From<&'a I> + for<'a> From<&'a I2>,
+        I4: Integer + for<'a> From<&'a I> + for<'a> From<&'a I2> + ToBytes,
+        I2: Integer + for<'a> From<&'a I>,
         KeccakTranscript: ZipTranscript<I2>;
 }
 
-impl<I: CryptoInteger, F: Field, S: ZipSpec> Prover<I, F> for ZincProver<I, F, S>
+impl<I: Integer, F: Field, S: ZipSpec> Prover<I, F> for ZincProver<I, F, S>
 where
-    for<'a> I: From<&'a F::I>,
-    for<'a> F::CryptoInt: From<&'a I::I>, // TODO
-    F::I: From<I>,
+    for<'a> I: From<&'a F::B>,
+    for<'a> F::I: From<&'a I::I>, // TODO
+    F::B: From<I>,
     I: FieldMap<F, Output = F>,
 {
     fn prove<I2, I4, I8>(
@@ -61,12 +61,12 @@ where
         wit: &Witness_Z<I>,
         transcript: &mut KeccakTranscript,
         ccs: &CCS_Z<I>,
-        config: F::Cr,
+        config: F::R,
     ) -> ZincResult<ZincProof<I, F>, F>
     where
-        I8: CryptoInteger + for<'a> From<&'a I> + for<'a> From<&'a I2>,
-        I4: CryptoInteger + for<'a> From<&'a I> + for<'a> From<&'a I2> + ToBytes,
-        I2: CryptoInteger + for<'a> From<&'a I>,
+        I8: Integer + for<'a> From<&'a I> + for<'a> From<&'a I2>,
+        I4: Integer + for<'a> From<&'a I> + for<'a> From<&'a I2> + ToBytes,
+        I2: Integer + for<'a> From<&'a I>,
         KeccakTranscript: ZipTranscript<I2>,
     {
         // TODO: Write functionality to let the verifier know that there are no denominators that can be divided by q(As an honest prover)
@@ -97,7 +97,7 @@ where
     }
 }
 /// Prover for the Spartan protocol
-pub trait SpartanProver<I: CryptoInteger, F: Field> {
+pub trait SpartanProver<I: Integer, F: Field> {
     /// Generates a proof for the spartan protocol
     ///
     /// # Arguments
@@ -124,15 +124,15 @@ pub trait SpartanProver<I: CryptoInteger, F: Field> {
         z_mle: &DenseMultilinearExtensionZ<I>,
         ccs_f: &CCS_F<F>,
         transcript: &mut KeccakTranscript,
-        config: F::Cr,
+        config: F::R,
     ) -> SpartanResult<(SpartanProof<F>, Vec<F>), F>;
 }
 
-impl<I: CryptoInteger, F: Field, S: ZipSpec> SpartanProver<I, F> for ZincProver<I, F, S>
+impl<I: Integer, F: Field, S: ZipSpec> SpartanProver<I, F> for ZincProver<I, F, S>
 where
-    for<'a> I: From<&'a F::I>,
-    for<'a> F::CryptoInt: From<&'a I::I>, // TODO
-    F::I: From<I>,
+    for<'a> I: From<&'a F::B>,
+    for<'a> F::I: From<&'a I::I>, // TODO
+    F::B: From<I>,
     I: FieldMap<F, Output = F>,
 {
     fn prove(
@@ -142,7 +142,7 @@ where
         z_mle: &DenseMultilinearExtensionZ<I>,
         ccs_f: &CCS_F<F>,
         transcript: &mut KeccakTranscript,
-        config: F::Cr,
+        config: F::R,
     ) -> SpartanResult<(SpartanProof<F>, Vec<F>), F> {
         // Do first Sumcheck
         let (sumcheck_proof_1, r_x, mz_mles) =
@@ -169,11 +169,11 @@ where
     }
 }
 
-impl<I: CryptoInteger, F: Field, S: ZipSpec> ZincProver<I, F, S>
+impl<I: Integer, F: Field, S: ZipSpec> ZincProver<I, F, S>
 where
-    for<'a> I: From<&'a F::I>,
-    for<'a> F::CryptoInt: From<&'a I::I>, // TODO
-    F::I: From<I>,
+    for<'a> I: From<&'a F::B>,
+    for<'a> F::I: From<&'a I::I>, // TODO
+    F::B: From<I>,
     I: FieldMap<F, Output = F>,
 {
     pub type DenseMleF = DenseMultilinearExtension<F>;
@@ -187,7 +187,7 @@ where
         statement: &Statement_Z<I>,
         wit: &Witness_Z<I>,
         ccs: &CCS_Z<I>,
-        config: F::Cr,
+        config: F::R,
     ) -> SpartanResult<(Vec<F>, Self::DenseMleZ, Self::CcsF, Self::StatementF), F> {
         // z_ccs vector, i.e. concatenation x || 1 || w.
         let (z_ccs, z_mle) = Self::get_z_ccs_and_z_mle(statement, wit, ccs, config);
@@ -203,7 +203,7 @@ where
         transcript: &mut KeccakTranscript,
         constraints: &[SparseMatrix<F>],
         ccs: &Self::CcsF,
-        config: F::Cr,
+        config: F::R,
     ) -> SpartanResult<(Vec<Self::DenseMleF>, usize, Vec<Self::DenseMleF>), F> {
         // Generate beta challenges from Step 1
         let beta_s = transcript.squeeze_beta_challenges(ccs.s, config);
@@ -222,7 +222,7 @@ where
         statement: &Statement_Z<I>,
         wit: &Witness_Z<I>,
         ccs: &CCS_Z<I>,
-        config: F::Cr,
+        config: F::R,
     ) -> (Vec<F>, Self::DenseMleZ) {
         let mut z_ccs = statement.get_z_vector(&wit.w_ccs);
 
@@ -243,7 +243,7 @@ where
         transcript: &mut KeccakTranscript,
         statement: &Self::StatementF,
         ccs: &Self::CcsF,
-        config: F::Cr,
+        config: F::R,
     ) -> SpartanResult<(SumcheckProof<F>, Vec<F>, Vec<Self::DenseMleF>), F> {
         let (g_mles, g_degree, mz_mles) = {
             Self::construct_polynomial_g(z_ccs, transcript, &statement.constraints, ccs, config)?
@@ -261,7 +261,7 @@ where
         r_a: &[F],
         ccs: &Self::CcsF,
         statement: &Self::StatementF,
-        config: F::Cr,
+        config: F::R,
         z_mle: &Self::DenseMleF,
         transcript: &mut KeccakTranscript,
     ) -> SpartanResult<(SumcheckProof<F>, Vec<F>), F> {
@@ -291,7 +291,7 @@ where
 
         let evals_mle =
             DenseMultilinearExtension::from_evaluations_vec(ccs.s_prime, evals, unsafe {
-                F::Cr::new(ccs.config.load(Ordering::Acquire))
+                F::R::new(ccs.config.load(Ordering::Acquire))
             });
 
         sumcheck_2_mles.push(evals_mle);
@@ -306,12 +306,12 @@ where
         ccs: &Self::CcsF,
         r_y: &[F],
         transcript: &mut KeccakTranscript,
-        config: F::Cr,
+        config: F::R,
     ) -> SpartanResult<ZipProof<I, F>, F>
     where
-        I8: CryptoInteger + for<'a> From<&'a I2> + for<'a> From<&'a I>,
-        I4: CryptoInteger + for<'a> From<&'a I2> + for<'a> From<&'a I> + ToBytes,
-        I2: CryptoInteger + for<'a> From<&'a I>,
+        I8: Integer + for<'a> From<&'a I2> + for<'a> From<&'a I>,
+        I4: Integer + for<'a> From<&'a I2> + for<'a> From<&'a I> + ToBytes,
+        I2: Integer + for<'a> From<&'a I>,
         KeccakTranscript: ZipTranscript<I2>,
     {
         let param = MultilinearZip::<I, I2, I4, I8, S, _>::setup(ccs.m, transcript);
@@ -341,7 +341,7 @@ where
     fn calculate_V_s(
         mz_mles: &[Self::DenseMleF],
         r_x: &[F],
-        config: F::Cr,
+        config: F::R,
     ) -> SpartanResult<Vec<F>, F> {
         let V_s: Result<Vec<F>, MleEvaluationError> = mz_mles
             .iter()
@@ -363,7 +363,7 @@ where
         nvars: usize,
         degree: usize,
         comb_fn: impl Fn(&[F]) -> F + Send + Sync,
-        config: F::Cr,
+        config: F::R,
     ) -> SpartanResult<(SumcheckProof<F>, Vec<F>), F> {
         let (sum_check_proof, prover_state) =
             MLSumcheck::prove_as_subprotocol(transcript, mles, nvars, degree, &comb_fn, config);

--- a/src/zinc/structs.rs
+++ b/src/zinc/structs.rs
@@ -2,7 +2,7 @@ use ark_std::{marker::PhantomData, vec::Vec};
 
 use crate::{
     sumcheck,
-    traits::{CryptoInteger, Field},
+    traits::{Field, Integer},
     zip::{code::ZipSpec, pcs::structs::MultilinearZipCommitment},
 };
 
@@ -23,19 +23,19 @@ pub struct SpartanProof<F> {
     pub V_s: Vec<F>,
 }
 
-pub struct ZipProof<I: CryptoInteger, F> {
+pub struct ZipProof<I: Integer, F> {
     pub z_comm: MultilinearZipCommitment<I>,
     pub v: F,
     pub pcs_proof: Vec<u8>,
 }
 
-pub struct ZincProof<I: CryptoInteger, F> {
+pub struct ZincProof<I: Integer, F> {
     pub spartan_proof: SpartanProof<F>,
     pub zip_proof: ZipProof<I, F>,
 }
 
 /// The implementation of the `LinearizationProver` trait is defined in the main linearization file.
-pub struct ZincProver<I: CryptoInteger, F: Field, S>
+pub struct ZincProver<I: Integer, F: Field, S>
 where
     S: ZipSpec,
 {
@@ -43,7 +43,7 @@ where
 }
 
 /// The implementation of the `LinearizationVerifier` trait is defined in the main linearization file.
-pub struct ZincVerifier<I: CryptoInteger, F: Field, S>
+pub struct ZincVerifier<I: Integer, F: Field, S>
 where
     S: ZipSpec,
 {

--- a/src/zinc/tests.rs
+++ b/src/zinc/tests.rs
@@ -4,7 +4,7 @@ use crypto_bigint::Zero;
 use crate::{
     biginteger::BigInt,
     ccs::{ccs_z::get_test_ccs_stuff_Z, test_utils::get_dummy_ccs_Z_from_z_length},
-    crypto_int::CryptoInt,
+    crypto_int::Int,
     field::RandomField,
     field_config::{ConfigRef, FieldConfig},
     traits::{Config, ConfigReference},
@@ -30,15 +30,15 @@ fn test_dummy_spartan_prover() {
     let (_, ccs, statement, wit) = get_dummy_ccs_Z_from_z_length(n, &mut rng);
     let mut prover_transcript = KeccakTranscript::new();
 
-    let prover = ZincProver::<CryptoInt<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
+    let prover = ZincProver::<Int<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
 
     let (z_ccs, z_mle, ccs_f, statement_f) =
-        ZincProver::<CryptoInt<I>, RandomField<N>, ZipSpec1>::prepare_for_random_field_piop(
+        ZincProver::<Int<I>, RandomField<N>, ZipSpec1>::prepare_for_random_field_piop(
             &statement, &wit, &ccs, config,
         )
         .expect("Failed to prepare for random field PIOP");
 
-    let proof = SpartanProver::<CryptoInt<I>, RandomField<N>>::prove(
+    let proof = SpartanProver::<Int<I>, RandomField<N>>::prove(
         &prover,
         &statement_f,
         &z_ccs,
@@ -63,15 +63,15 @@ fn test_spartan_verifier() {
     let (ccs, statement, wit, _) = get_test_ccs_stuff_Z(input);
     let mut prover_transcript = KeccakTranscript::new();
 
-    let prover = ZincProver::<CryptoInt<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
+    let prover = ZincProver::<Int<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
 
     let (z_ccs, z_mle, ccs_f, statement_f) =
-        ZincProver::<CryptoInt<I>, RandomField<N>, ZipSpec1>::prepare_for_random_field_piop(
+        ZincProver::<Int<I>, RandomField<N>, ZipSpec1>::prepare_for_random_field_piop(
             &statement, &wit, &ccs, config,
         )
         .expect("Failed to prepare for random field PIOP");
 
-    let (spartan_proof, _) = SpartanProver::<CryptoInt<I>, RandomField<N>>::prove(
+    let (spartan_proof, _) = SpartanProver::<Int<I>, RandomField<N>>::prove(
         &prover,
         &statement_f,
         &z_ccs,
@@ -82,7 +82,7 @@ fn test_spartan_verifier() {
     )
     .expect("Failed to generate Spartan proof");
 
-    let verifier = ZincVerifier::<CryptoInt<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
+    let verifier = ZincVerifier::<Int<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
     let mut verifier_transcript = KeccakTranscript::new();
 
     config.reference().expect("Field config cannot be none");
@@ -110,15 +110,15 @@ fn test_dummy_spartan_verifier() {
     let (_, ccs, statement, wit) = get_dummy_ccs_Z_from_z_length(n, &mut rng);
     let mut prover_transcript = KeccakTranscript::new();
 
-    let prover = ZincProver::<CryptoInt<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
+    let prover = ZincProver::<Int<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
 
     let (z_ccs, z_mle, ccs_f, statement_f) =
-        ZincProver::<CryptoInt<I>, RandomField<N>, ZipSpec1>::prepare_for_random_field_piop(
+        ZincProver::<Int<I>, RandomField<N>, ZipSpec1>::prepare_for_random_field_piop(
             &statement, &wit, &ccs, config,
         )
         .expect("Failed to prepare for random field PIOP");
 
-    let (spartan_proof, _) = SpartanProver::<CryptoInt<I>, RandomField<N>>::prove(
+    let (spartan_proof, _) = SpartanProver::<Int<I>, RandomField<N>>::prove(
         &prover,
         &statement_f,
         &z_ccs,
@@ -129,7 +129,7 @@ fn test_dummy_spartan_verifier() {
     )
     .expect("Failed to generate Spartan proof");
 
-    let verifier = ZincVerifier::<CryptoInt<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
+    let verifier = ZincVerifier::<Int<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
     let mut verifier_transcript = KeccakTranscript::new();
     config.reference().expect("Field config cannot be none");
     let res = SpartanVerifier::<RandomField<N>>::verify(
@@ -153,19 +153,19 @@ fn test_failing_spartan_verifier() {
     let config = ConfigRef::from(&config);
     let (ccs, statement, mut wit, _) = get_test_ccs_stuff_Z(input);
     // Change the witness such that it is no longer valid
-    assert!(wit.w_ccs[3] != CryptoInt::<I>::zero());
-    wit.w_ccs[3] = CryptoInt::<I>::zero();
+    assert!(wit.w_ccs[3] != Int::<I>::zero());
+    wit.w_ccs[3] = Int::<I>::zero();
     let mut prover_transcript = KeccakTranscript::new();
 
-    let prover = ZincProver::<CryptoInt<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
+    let prover = ZincProver::<Int<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
 
     let (z_ccs, z_mle, ccs_f, statement_f) =
-        ZincProver::<CryptoInt<I>, RandomField<N>, ZipSpec1>::prepare_for_random_field_piop(
+        ZincProver::<Int<I>, RandomField<N>, ZipSpec1>::prepare_for_random_field_piop(
             &statement, &wit, &ccs, config,
         )
         .expect("Failed to prepare for random field PIOP");
 
-    let (spartan_proof, _) = SpartanProver::<CryptoInt<I>, RandomField<N>>::prove(
+    let (spartan_proof, _) = SpartanProver::<Int<I>, RandomField<N>>::prove(
         &prover,
         &statement_f,
         &z_ccs,
@@ -176,7 +176,7 @@ fn test_failing_spartan_verifier() {
     )
     .expect("Failed to generate Spartan proof");
 
-    let verifier = ZincVerifier::<CryptoInt<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
+    let verifier = ZincVerifier::<Int<I>, RandomField<N>, ZipSpec1> { data: PhantomData };
     let mut verifier_transcript = KeccakTranscript::new();
 
     config.reference().expect("Field config cannot be none");

--- a/src/zinc/utils.rs
+++ b/src/zinc/utils.rs
@@ -10,7 +10,7 @@ use crate::{
     prime_gen::get_prime,
     sparse_matrix::SparseMatrix,
     sumcheck::utils::build_eq_x_r,
-    traits::{Config, CryptoInteger, Field},
+    traits::{Config, Field, Integer},
     transcript::KeccakTranscript,
 };
 
@@ -52,7 +52,7 @@ pub fn prepare_lin_sumcheck_polynomial<F: Field>(
     M_mles: &[DenseMultilinearExtension<F>],
     S: &[Vec<usize>],
     beta_s: &[F],
-    config: F::Cr,
+    config: F::R,
 ) -> Result<(Vec<DenseMultilinearExtension<F>>, usize), SpartanError<F>> {
     let len = 1 + c
         .iter()
@@ -94,11 +94,11 @@ pub(crate) fn sumcheck_polynomial_comb_fn_1<F: Field>(vals: &[F], ccs: &CCS_F<F>
 }
 
 pub(crate) trait SqueezeBeta<F: Field> {
-    fn squeeze_beta_challenges(&mut self, n: usize, config: F::Cr) -> Vec<F>;
+    fn squeeze_beta_challenges(&mut self, n: usize, config: F::R) -> Vec<F>;
 }
 
 impl<F: Field> SqueezeBeta<F> for KeccakTranscript {
-    fn squeeze_beta_challenges(&mut self, n: usize, config: F::Cr) -> Vec<F> {
+    fn squeeze_beta_challenges(&mut self, n: usize, config: F::R) -> Vec<F> {
         self.absorb(b"beta_s");
 
         self.get_challenges(n, config)
@@ -106,11 +106,11 @@ impl<F: Field> SqueezeBeta<F> for KeccakTranscript {
 }
 
 pub(crate) trait SqueezeGamma<F: Field> {
-    fn squeeze_gamma_challenge(&mut self, config: F::Cr) -> F;
+    fn squeeze_gamma_challenge(&mut self, config: F::R) -> F;
 }
 
 impl<F: Field> SqueezeGamma<F> for KeccakTranscript {
-    fn squeeze_gamma_challenge(&mut self, config: F::Cr) -> F {
+    fn squeeze_gamma_challenge(&mut self, config: F::R) -> F {
         self.absorb(b"gamma");
 
         self.get_challenge(config)
@@ -122,7 +122,7 @@ pub(super) fn calculate_Mz_mles<E, F: Field>(
     constraints: &[SparseMatrix<F>],
     ccs_s: usize,
     z_ccs: &[F],
-    config: F::Cr,
+    config: F::R,
 ) -> Result<Vec<DenseMultilinearExtension<F>>, E>
 where
     E: From<MleEvaluationError> + From<CSError> + Sync + Send,
@@ -137,7 +137,7 @@ where
 fn to_mles_err<F: Field, I, E, E1>(
     n_vars: usize,
     mle_s: I,
-    config: F::Cr,
+    config: F::R,
 ) -> Result<Vec<DenseMultilinearExtension<F>>, E>
 where
     I: IntoIterator<Item = Result<Vec<F>, E1>>,
@@ -158,7 +158,7 @@ where
         .collect::<Result<_, E>>()
 }
 
-pub fn draw_random_field<I: CryptoInteger, F: Field>(
+pub fn draw_random_field<I: Integer, F: Field>(
     public_inputs: &[I],
     transcript: &mut KeccakTranscript,
 ) -> F::C {

--- a/src/zinc/verifier.rs
+++ b/src/zinc/verifier.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     poly_f::mle::DenseMultilinearExtension,
     sumcheck::{utils::eq_eval, MLSumcheck, SumCheckError::SumCheckFailed, SumcheckProof},
-    traits::{ConfigReference, CryptoInteger, Field, FieldMap},
+    traits::{ConfigReference, Field, FieldMap, Integer},
     transcript::KeccakTranscript,
     zip::{
         code::ZipSpec,
@@ -24,28 +24,32 @@ use crate::{
     },
 };
 
-pub trait Verifier<I: CryptoInteger, F: Field> {
+pub trait Verifier<I: Integer, F: Field> {
     fn verify<I2, I4, I8>(
         &self,
         cm_i: &Statement_Z<I>,
         proof: ZincProof<I, F>,
         transcript: &mut KeccakTranscript,
         ccs: &CCS_Z<I>,
-        config: F::Cr,
+        config: F::R,
     ) -> Result<(), ZincError<F>>
     where
-        I2: CryptoInteger + FieldMap<F, Output = F> + for<'a> From<&'a I>,
-        I4: CryptoInteger + FieldMap<F, Output = F> + ToBytes,
-        I8: CryptoInteger + for<'a> From<&'a I2> + for<'a> From<&'a I> + for<'a> From<&'a I4>,
+        I2: Integer + FieldMap<F, Output = F> + for<'a> From<&'a I>,
+        I4: Integer + FieldMap<F, Output = F> + ToBytes,
+        I8: Integer
+            + for<'a> From<&'a I2>
+            + for<'a> From<&'a I>
+            + for<'a> From<&'a I4>
+            + for<'a> From<&'a I4>,
         KeccakTranscript: ZipTranscript<I2>;
 }
 
 // TODO
-impl<I: CryptoInteger, F: Field, S: ZipSpec> Verifier<I, F> for ZincVerifier<I, F, S>
+impl<I: Integer, F: Field, S: ZipSpec> Verifier<I, F> for ZincVerifier<I, F, S>
 where
-    for<'a> I: From<&'a F::I>,
-    F::I: From<I>,
-    for<'a> F::CryptoInt: From<&'a I::I>,
+    for<'a> I: From<&'a F::B>,
+    F::B: From<I>,
+    for<'a> F::I: From<&'a I::I>,
     I: FieldMap<F, Output = F>,
     Self: SpartanVerifier<F>,
 {
@@ -55,16 +59,17 @@ where
         proof: ZincProof<I, F>,
         transcript: &mut KeccakTranscript,
         ccs: &CCS_Z<I>,
-        config: F::Cr,
+        config: F::R,
     ) -> Result<(), ZincError<F>>
     where
-        I2: CryptoInteger + FieldMap<F, Output = F> + for<'a> From<&'a I>,
-        I4: CryptoInteger + FieldMap<F, Output = F> + ToBytes,
-        I8: CryptoInteger + for<'a> From<&'a I2> + for<'a> From<&'a I> + for<'a> From<&'a I4>,
+        I2: Integer + FieldMap<F, Output = F> + for<'a> From<&'a I>,
+        I4: Integer + FieldMap<F, Output = F> + ToBytes,
+        I8: Integer
+            + for<'a> From<&'a I2>
+            + for<'a> From<&'a I>
+            + for<'a> From<&'a I4>
+            + for<'a> From<&'a I4>,
         KeccakTranscript: ZipTranscript<I2>,
-        I2: CryptoInteger + FieldMap<F, Output = F> + for<'a> From<&'a I>,
-        I4: CryptoInteger + FieldMap<F, Output = F> + ToBytes,
-        I8: CryptoInteger + for<'a> From<&'a I2> + for<'a> From<&'a I> + for<'a> From<&'a I4>,
     {
         if draw_random_field::<I, F>(&statement.public_input, transcript)
             != *config.reference().unwrap()
@@ -113,17 +118,17 @@ pub trait SpartanVerifier<F: Field> {
         proof: &SpartanProof<F>,
         ccs: &CCS_F<F>,
         transcript: &mut KeccakTranscript,
-        config: F::Cr,
+        config: F::R,
     ) -> Result<VerificationPoints<F>, SpartanError<F>>;
 }
 
-impl<I: CryptoInteger, F: Field, S: ZipSpec> SpartanVerifier<F> for ZincVerifier<I, F, S> {
+impl<I: Integer, F: Field, S: ZipSpec> SpartanVerifier<F> for ZincVerifier<I, F, S> {
     fn verify(
         &self,
         proof: &SpartanProof<F>,
         ccs: &CCS_F<F>,
         transcript: &mut KeccakTranscript,
-        config: F::Cr,
+        config: F::R,
     ) -> Result<VerificationPoints<F>, SpartanError<F>> {
         // Step 1: Generate the beta challenges.
         let beta_s = transcript.squeeze_beta_challenges(ccs.s, config);
@@ -154,7 +159,7 @@ impl<I: CryptoInteger, F: Field, S: ZipSpec> SpartanVerifier<F> for ZincVerifier
     }
 }
 
-impl<I: CryptoInteger, F: Field, S: ZipSpec> ZincVerifier<I, F, S> {
+impl<I: Integer, F: Field, S: ZipSpec> ZincVerifier<I, F, S> {
     fn verify_linearization_proof(
         &self,
         proof: &SumcheckProof<F>,
@@ -171,7 +176,7 @@ impl<I: CryptoInteger, F: Field, S: ZipSpec> ZincVerifier<I, F, S> {
             degree,
             F::zero(),
             proof,
-            unsafe { F::Cr::new(*ccs.config.as_ptr()) },
+            unsafe { F::R::new(*ccs.config.as_ptr()) },
         )?;
 
         Ok((subclaim.point, subclaim.expected_evaluation))
@@ -219,7 +224,7 @@ impl<I: CryptoInteger, F: Field, S: ZipSpec> ZincVerifier<I, F, S> {
             degree,
             claimed_sum,
             proof,
-            unsafe { F::Cr::new(*ccs.config.as_ptr()) },
+            unsafe { F::R::new(*ccs.config.as_ptr()) },
         )?;
 
         Ok((subclaim.point, subclaim.expected_evaluation))
@@ -241,12 +246,16 @@ impl<I: CryptoInteger, F: Field, S: ZipSpec> ZincVerifier<I, F, S> {
         verification_points: &VerificationPoints<F>,
         ccs: &CCS_F<F>,
         transcript: &mut KeccakTranscript,
-        config: F::Cr,
+        config: F::R,
     ) -> Result<(), SpartanError<F>>
     where
-        I2: CryptoInteger + FieldMap<F, Output = F> + for<'a> From<&'a I>,
-        I4: CryptoInteger + FieldMap<F, Output = F> + ToBytes,
-        I8: CryptoInteger + for<'a> From<&'a I2> + for<'a> From<&'a I> + for<'a> From<&'a I4>,
+        I2: Integer + FieldMap<F, Output = F> + for<'a> From<&'a I>,
+        I4: Integer + FieldMap<F, Output = F> + ToBytes,
+        I8: Integer
+            + for<'a> From<&'a I2>
+            + for<'a> From<&'a I>
+            + for<'a> From<&'a I4>
+            + for<'a> From<&'a I4>,
         KeccakTranscript: ZipTranscript<I2>,
     {
         let param = MultilinearZip::<I, I2, I4, I8, S, KeccakTranscript>::setup(ccs.m, transcript);

--- a/src/zip/pcs/commit.rs
+++ b/src/zip/pcs/commit.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     poly_z::mle::DenseMultilinearExtension,
-    traits::{CryptoInteger, Field},
+    traits::{Field, Integer},
     zip::{
         code::{LinearCodes, Zip, ZipSpec},
         pcs::utils::ToBytes,
@@ -15,8 +15,7 @@ use crate::{
     },
 };
 
-impl<I: CryptoInteger, L: CryptoInteger, K: CryptoInteger, M: CryptoInteger, S, T>
-    MultilinearZip<I, L, K, M, S, T>
+impl<I: Integer, L: Integer, K: Integer, M: Integer, S, T> MultilinearZip<I, L, K, M, S, T>
 where
     S: ZipSpec,
     T: ZipTranscript<L>,

--- a/src/zip/pcs/open_z.rs
+++ b/src/zip/pcs/open_z.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     poly_z::mle::DenseMultilinearExtension,
-    traits::{CryptoInteger, Field, FieldMap},
+    traits::{Field, FieldMap, Integer},
     zip::{
         code::{LinearCodes, Zip, ZipSpec},
         pcs_transcript::PcsTranscript,
@@ -17,8 +17,7 @@ use crate::{
     },
 };
 
-impl<I: CryptoInteger, L: CryptoInteger, K: CryptoInteger, M: CryptoInteger, S, T>
-    MultilinearZip<I, L, K, M, S, T>
+impl<I: Integer, L: Integer, K: Integer, M: Integer, S, T> MultilinearZip<I, L, K, M, S, T>
 where
     S: ZipSpec,
     T: ZipTranscript<L>,
@@ -31,7 +30,7 @@ where
         poly: &Self::Polynomial,
         commit_data: &Self::Data,
         point: &[F],
-        field: F::Cr,
+        field: F::R,
         transcript: &mut PcsTranscript<F>,
     ) -> Result<(), Error>
     where
@@ -53,7 +52,7 @@ where
         comms: impl Iterable<Item = &'a MultilinearZipData<I, K>>,
         points: &[Vec<F>],
         transcript: &mut PcsTranscript<F>,
-        field: F::Cr,
+        field: F::R,
     ) -> Result<(), Error>
     where
         I: FieldMap<F, Output = F> + 'a,
@@ -71,7 +70,7 @@ where
         transcript: &mut PcsTranscript<F>,
         point: &[F],
         poly: &Self::Polynomial,
-        field: F::Cr,
+        field: F::R,
     ) -> Result<(), Error>
     where
         I: FieldMap<F, Output = F>,
@@ -102,7 +101,7 @@ where
         poly: &Self::Polynomial,
         commit_data: &Self::Data,
         transcript: &mut PcsTranscript<F>,
-        field: F::Cr, // This is only needed to called the transcript but we are getting integers not fields
+        field: F::R, // This is only needed to called the transcript but we are getting integers not fields
     ) -> Result<(), Error> {
         if pp.num_rows() > 1 {
             // If we can take linear combinations

--- a/src/zip/pcs/structs.rs
+++ b/src/zip/pcs/structs.rs
@@ -4,7 +4,7 @@ use sha3::{digest::Output, Keccak256};
 use super::utils::MerkleTree;
 use crate::{
     poly_z::mle::DenseMultilinearExtension as DenseMultilinearExtensionZ,
-    traits::CryptoInteger,
+    traits::Integer,
     zip::code::{LinearCodes, Zip, ZipSpec},
 };
 
@@ -14,22 +14,22 @@ use crate::{
 // M is the width of elements in linear combination of code rows
 #[derive(Debug, Clone)]
 pub struct MultilinearZip<
-    N: CryptoInteger,
-    L: CryptoInteger,
-    K: CryptoInteger,
-    M: CryptoInteger,
+    N: Integer,
+    L: Integer,
+    K: Integer,
+    M: Integer,
     S: ZipSpec,
     T: ZipTranscript<L>,
 >(PhantomData<(N, L, K, M, S, T)>);
 
 #[derive(Clone, Debug)]
-pub struct MultilinearZipParams<N: CryptoInteger, L: CryptoInteger> {
+pub struct MultilinearZipParams<N: Integer, L: Integer> {
     num_vars: usize,
     num_rows: usize,
     zip: Zip<N, L>,
 }
 
-impl<N: CryptoInteger, L: CryptoInteger> MultilinearZipParams<N, L> {
+impl<N: Integer, L: Integer> MultilinearZipParams<N, L> {
     pub fn num_vars(&self) -> usize {
         self.num_vars
     }
@@ -45,7 +45,7 @@ impl<N: CryptoInteger, L: CryptoInteger> MultilinearZipParams<N, L> {
 
 /// Representantation of a zip commitment to a multilinear polynomial
 #[derive(Clone, Debug, Default)]
-pub struct MultilinearZipData<N: CryptoInteger, K: CryptoInteger> {
+pub struct MultilinearZipData<N: Integer, K: Integer> {
     /// The encoded rows of the polynomial matrix representation
     rows: Vec<K>,
     /// Merkle trees of each row
@@ -54,12 +54,12 @@ pub struct MultilinearZipData<N: CryptoInteger, K: CryptoInteger> {
 }
 /// Representantation of a zip commitment to a multilinear polynomial
 #[derive(Clone, Debug, Default)]
-pub struct MultilinearZipCommitment<I: CryptoInteger> {
+pub struct MultilinearZipCommitment<I: Integer> {
     /// Roots of the merkle tree of each row
     roots: Vec<Output<Keccak256>>,
     phantom: PhantomData<I>,
 }
-impl<I: CryptoInteger> MultilinearZipCommitment<I> {
+impl<I: Integer> MultilinearZipCommitment<I> {
     pub fn new(roots: Vec<Output<Keccak256>>) -> MultilinearZipCommitment<I> {
         MultilinearZipCommitment {
             roots,
@@ -71,7 +71,7 @@ impl<I: CryptoInteger> MultilinearZipCommitment<I> {
     }
 }
 
-impl<N: CryptoInteger, K: CryptoInteger> MultilinearZipData<N, K> {
+impl<N: Integer, K: Integer> MultilinearZipData<N, K> {
     pub fn new(rows: Vec<K>, rows_merkle_trees: Vec<MerkleTree>) -> MultilinearZipData<N, K> {
         MultilinearZipData {
             rows,
@@ -100,7 +100,7 @@ impl<N: CryptoInteger, K: CryptoInteger> MultilinearZipData<N, K> {
     }
 }
 
-pub trait ZipTranscript<I: CryptoInteger> {
+pub trait ZipTranscript<I: Integer> {
     fn get_encoding_element(&mut self) -> I;
     fn sample_unique_columns(
         &mut self,
@@ -109,8 +109,7 @@ pub trait ZipTranscript<I: CryptoInteger> {
         count: usize,
     ) -> usize;
 }
-impl<I: CryptoInteger, L: CryptoInteger, K: CryptoInteger, M: CryptoInteger, S, T>
-    MultilinearZip<I, L, K, M, S, T>
+impl<I: Integer, L: Integer, K: Integer, M: Integer, S, T> MultilinearZip<I, L, K, M, S, T>
 where
     S: ZipSpec,
     T: ZipTranscript<L>,

--- a/src/zip/pcs/utils.rs
+++ b/src/zip/pcs/utils.rs
@@ -7,7 +7,7 @@ use crate::{
     poly_f::mle::DenseMultilinearExtension as MLE_F,
     poly_z::mle::DenseMultilinearExtension as MLE_Z,
     sumcheck::utils::build_eq_x_r as build_eq_x_r_f,
-    traits::{CryptoInteger, Field},
+    traits::{Field, Integer},
     zip::{
         pcs_transcript::PcsTranscript,
         utils::{div_ceil, num_threads, parallelize, parallelize_iter},
@@ -24,7 +24,7 @@ fn err_too_many_variates(function: &str, upto: usize, got: usize) -> Error {
 }
 
 // Ensures that polynomials and evaluation points are of appropriate size
-pub(super) fn validate_input<'a, I: CryptoInteger + 'a, F: Field + 'a>(
+pub(super) fn validate_input<'a, I: Integer + 'a, F: Field + 'a>(
     function: &str,
     param_num_vars: usize,
     polys: impl Iterable<Item = &'a MLE_Z<I>>,
@@ -214,7 +214,7 @@ impl MerkleProof {
 pub struct ColumnOpening {}
 
 impl ColumnOpening {
-    pub fn open_at_column<F: Field, I: CryptoInteger, M: CryptoInteger>(
+    pub fn open_at_column<F: Field, I: Integer, M: Integer>(
         column: usize,
         commit_data: &MultilinearZipData<I, M>,
         transcript: &mut PcsTranscript<F>,
@@ -249,7 +249,7 @@ impl ColumnOpening {
 pub(super) fn point_to_tensor<F: Field>(
     num_rows: usize,
     point: &[F],
-    config: F::Cr,
+    config: F::R,
 ) -> Result<(Vec<F>, Vec<F>), Error> {
     assert!(num_rows.is_power_of_two());
     let (hi, lo) = point.split_at(point.len() - num_rows.ilog2() as usize);
@@ -275,7 +275,7 @@ pub(super) fn point_to_tensor<F: Field>(
 pub(super) fn left_point_to_tensor<F: Field>(
     num_rows: usize,
     point: &[F],
-    config: F::Cr,
+    config: F::R,
 ) -> Result<Vec<F>, Error> {
     let (_, lo) = point.split_at(point.len() - num_rows.ilog2() as usize);
     // TODO: get rid of these unwraps.
@@ -292,7 +292,7 @@ mod tests {
     use crypto_bigint::Random;
 
     use super::*;
-    use crate::{crypto_int::CryptoInt, zip::utils::combine_rows};
+    use crate::{crypto_int::Int, zip::utils::combine_rows};
 
     #[test]
     fn test_basic_combination() {
@@ -338,8 +338,8 @@ mod tests {
         let leaves_len = 1024;
         let mut rng = ark_std::test_rng();
         let leaves_data = (0..leaves_len)
-            .map(|_| CryptoInt::random(&mut rng))
-            .collect::<Vec<CryptoInt<N>>>();
+            .map(|_| Int::random(&mut rng))
+            .collect::<Vec<Int<N>>>();
 
         let merkle_depth = leaves_data.len().next_power_of_two().ilog2() as usize;
         let merkle_tree = MerkleTree::new(merkle_depth, &leaves_data);

--- a/src/zip/pcs/verify_z.rs
+++ b/src/zip/pcs/verify_z.rs
@@ -6,7 +6,7 @@ use super::{
     utils::{point_to_tensor, validate_input, ColumnOpening},
 };
 use crate::{
-    traits::{CryptoInteger, Field, FieldMap},
+    traits::{Field, FieldMap, Integer},
     zip::{
         code::{LinearCodes, Zip, ZipSpec},
         pcs::utils::ToBytes,
@@ -16,7 +16,7 @@ use crate::{
     },
 };
 
-impl<I: CryptoInteger, L: CryptoInteger, K: CryptoInteger + ToBytes, M: CryptoInteger, S, T>
+impl<I: Integer, L: Integer, K: Integer + ToBytes, M: Integer, S, T>
     MultilinearZip<I, L, K, M, S, T>
 where
     S: ZipSpec,
@@ -31,7 +31,7 @@ where
         point: &[F],
         eval: F,
         transcript: &mut PcsTranscript<F>,
-        field: F::Cr,
+        field: F::R,
     ) -> Result<(), Error>
     where
         L: FieldMap<F, Output = F>,
@@ -52,7 +52,7 @@ where
         points: &[Vec<F>],
         evals: &[F],
         transcript: &mut PcsTranscript<F>,
-        field: F::Cr,
+        field: F::R,
     ) -> Result<(), Error>
     where
         L: FieldMap<F, Output = F>,
@@ -69,7 +69,7 @@ where
         vp: &Self::VerifierParam,
         roots: &[Output<Keccak256>],
         transcript: &mut PcsTranscript<F>,
-        field: F::Cr,
+        field: F::R,
     ) -> Result<Vec<(usize, Vec<K>)>, Error> {
         // Gather the coeffs and encoded combined rows per proximity test
         let mut encoded_combined_rows = Vec::with_capacity(
@@ -143,7 +143,7 @@ where
         eval: F,
         columns_opened: &[(usize, Vec<K>)],
         transcript: &mut PcsTranscript<F>,
-        field: F::Cr,
+        field: F::R,
     ) -> Result<(), Error>
     where
         L: FieldMap<F, Output = F>,
@@ -180,7 +180,7 @@ where
         column_entries: &[K],
         column: usize,
         num_rows: usize,
-        field: F::Cr,
+        field: F::R,
     ) -> Result<(), Error>
     where
         K: FieldMap<F, Output = F>,

--- a/src/zip/pcs_transcript.rs
+++ b/src/zip/pcs_transcript.rs
@@ -11,7 +11,7 @@ use sha3::{digest::Output, Keccak256};
 use super::{pcs::utils::MerkleProof, Error};
 use crate::{
     poly::alloc::string::ToString,
-    traits::{CryptoInteger, Field, FromBytes, Integer, Words},
+    traits::{BigInteger, Field, FromBytes, Integer, Words},
     transcript::KeccakTranscript,
 };
 
@@ -67,20 +67,20 @@ impl<F: Field> PcsTranscript<F> {
         Ok(())
     }
 
-    pub fn read_field_elements(&mut self, n: usize, config: F::Cr) -> Result<Vec<F>, Error> {
+    pub fn read_field_elements(&mut self, n: usize, config: F::R) -> Result<Vec<F>, Error> {
         (0..n)
             .map(|_| self.read_field_element(config))
             .collect::<Result<Vec<_>, _>>()
     }
 
-    pub fn read_field_element(&mut self, config: F::Cr) -> Result<F, Error> {
+    pub fn read_field_element(&mut self, config: F::R) -> Result<F, Error> {
         let mut bytes: Vec<u8> = vec![0; F::W::num_words() * 8];
 
         self.stream
             .read_exact(&mut bytes)
             .map_err(|err| Error::Transcript(err.kind(), err.to_string()))?;
 
-        let fe = F::new_unchecked(config, F::I::from_bytes_be(&bytes).unwrap());
+        let fe = F::new_unchecked(config, F::B::from_bytes_be(&bytes).unwrap());
 
         self.common_field_element(&fe);
         Ok(fe)
@@ -94,7 +94,7 @@ impl<F: Field> PcsTranscript<F> {
             .map_err(|err| Error::Transcript(err.kind(), err.to_string()))
     }
 
-    pub fn write_integer<M: CryptoInteger>(&mut self, int: &M) -> Result<(), Error> {
+    pub fn write_integer<M: Integer>(&mut self, int: &M) -> Result<(), Error> {
         for &word in int.as_words().iter() {
             let bytes = word.to_le_bytes();
             self.stream
@@ -112,7 +112,7 @@ impl<F: Field> PcsTranscript<F> {
 
     pub fn write_integers<'a, M, I>(&mut self, ints: I) -> Result<(), Error>
     where
-        M: CryptoInteger + 'a,
+        M: Integer + 'a,
         I: Iterator<Item = &'a M>,
     {
         for i in ints {
@@ -122,7 +122,7 @@ impl<F: Field> PcsTranscript<F> {
         Ok(())
     }
 
-    pub fn read_integer<M: CryptoInteger>(&mut self) -> Result<M, Error> {
+    pub fn read_integer<M: Integer>(&mut self) -> Result<M, Error> {
         let mut words = M::W::default();
 
         for word in words[0..M::W::num_words()].iter_mut() {
@@ -136,7 +136,7 @@ impl<F: Field> PcsTranscript<F> {
         Ok(M::from_words(words))
     }
 
-    pub fn read_integers<M: CryptoInteger>(&mut self, n: usize) -> Result<Vec<M>, Error> {
+    pub fn read_integers<M: Integer>(&mut self, n: usize) -> Result<Vec<M>, Error> {
         (0..n)
             .map(|_| self.read_integer())
             .collect::<Result<Vec<_>, _>>()
@@ -156,7 +156,7 @@ impl<F: Field> PcsTranscript<F> {
         Ok(())
     }
 
-    pub fn squeeze_challenge_idx(&mut self, config: F::Cr, cap: usize) -> usize {
+    pub fn squeeze_challenge_idx(&mut self, config: F::R, cap: usize) -> usize {
         let challenge: F = self.fs_transcript.get_challenge(config);
         let bytes = challenge.value().to_bytes_le();
         let num = u32::from_le_bytes(bytes[..4].try_into().unwrap()) as usize;

--- a/src/zip/tests.rs
+++ b/src/zip/tests.rs
@@ -2,7 +2,7 @@ use ark_std::{str::FromStr, vec, vec::Vec, UniformRand};
 
 use crate::{
     biginteger::BigInt,
-    crypto_int::CryptoInt,
+    crypto_int::Int,
     field::RandomField,
     field_config::{ConfigRef, FieldConfig},
     poly_z::mle::DenseMultilinearExtension,
@@ -15,10 +15,10 @@ const I: usize = 1;
 const N: usize = 2;
 
 type TestZip = MultilinearZip<
-    CryptoInt<I>,
-    CryptoInt<{ 2 * I }>,
-    CryptoInt<{ 4 * I }>,
-    CryptoInt<{ 8 * I }>,
+    Int<I>,
+    Int<{ 2 * I }>,
+    Int<{ 4 * I }>,
+    Int<{ 8 * I }>,
     ZipSpec1,
     KeccakTranscript,
 >;
@@ -28,7 +28,7 @@ fn test_zip_commitment() {
     let mut transcript = KeccakTranscript::new();
     let param: TestZip::Param = TestZip::setup(8, &mut transcript);
 
-    let evaluations: Vec<_> = (0..8).map(CryptoInt::<I>::from).collect();
+    let evaluations: Vec<_> = (0..8).map(Int::<I>::from).collect();
 
     let n = 3;
     let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations);
@@ -43,7 +43,7 @@ fn test_failing_zip_commitment() {
     let mut transcript = KeccakTranscript::new();
     let param: TestZip::Param = TestZip::setup(8, &mut transcript);
 
-    let evaluations: Vec<_> = (0..16).map(CryptoInt::<I>::from).collect();
+    let evaluations: Vec<_> = (0..16).map(Int::<I>::from).collect();
     let n = 4;
     let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations);
 
@@ -62,7 +62,7 @@ fn test_zip_opening() {
 
     let mut transcript = PcsTranscript::<RandomField<N>>::new();
 
-    let evaluations: Vec<_> = (0..8).map(CryptoInt::<I>::from).collect();
+    let evaluations: Vec<_> = (0..8).map(Int::<I>::from).collect();
     let n = 3;
     let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations);
 
@@ -84,7 +84,7 @@ fn test_failing_zip_evaluation() {
     let mut keccak_transcript = KeccakTranscript::new();
     let param: TestZip::Param = TestZip::setup(8, &mut keccak_transcript);
 
-    let evaluations: Vec<_> = (0..8).map(CryptoInt::<I>::from).collect();
+    let evaluations: Vec<_> = (0..8).map(Int::<I>::from).collect();
     let n = 3;
     let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations);
 
@@ -115,15 +115,13 @@ fn test_zip_evaluation() {
     let mut keccak_transcript = KeccakTranscript::new();
     let param: TestZip::Param = TestZip::setup(1 << n, &mut keccak_transcript);
     let evaluations: Vec<_> = (0..(1 << n))
-        .map(|_| CryptoInt::<I>::from(i8::rand(&mut rng)))
+        .map(|_| Int::<I>::from(i8::rand(&mut rng)))
         .collect();
     let mle = DenseMultilinearExtension::from_evaluations_slice(n, &evaluations);
 
     let (data, comm) = TestZip::commit::<RandomField<N>>(&param, &mle).unwrap();
 
-    let point: Vec<_> = (0..n)
-        .map(|_| CryptoInt::<I>::from(i8::rand(&mut rng)))
-        .collect();
+    let point: Vec<_> = (0..n).map(|_| Int::<I>::from(i8::rand(&mut rng))).collect();
     let eval: F = mle.evaluate(&point).unwrap().map_to_field(config);
 
     let point = point.map_to_field(config);
@@ -148,11 +146,11 @@ fn test_zip_batch_evaluation() {
     let m = 10;
     let mut keccak_transcript = KeccakTranscript::new();
     let param: TestZip::Param = TestZip::setup(1 << n, &mut keccak_transcript);
-    let evaluations: Vec<Vec<CryptoInt<I>>> = (0..m)
+    let evaluations: Vec<Vec<Int<I>>> = (0..m)
         .map(|_| {
             (0..(1 << n))
-                .map(|_| CryptoInt::<I>::from(i8::rand(&mut rng)))
-                .collect::<Vec<CryptoInt<I>>>()
+                .map(|_| Int::<I>::from(i8::rand(&mut rng)))
+                .collect::<Vec<Int<I>>>()
         })
         .collect();
 
@@ -163,9 +161,7 @@ fn test_zip_batch_evaluation() {
 
     let commitments: Vec<_> = TestZip::batch_commit::<RandomField<N>>(&param, &mles).unwrap();
     let (data, commitments): (Vec<_>, Vec<_>) = commitments.into_iter().unzip();
-    let point: Vec<_> = (0..n)
-        .map(|_| CryptoInt::<I>::from(i8::rand(&mut rng)))
-        .collect();
+    let point: Vec<_> = (0..n).map(|_| Int::<I>::from(i8::rand(&mut rng))).collect();
     let eval: Vec<_> = mles
         .iter()
         .map(|mle| mle.evaluate(&point).unwrap().map_to_field(config))

--- a/src/zip/utils.rs
+++ b/src/zip/utils.rs
@@ -3,9 +3,9 @@ use ark_std::{
     vec,
     vec::Vec,
 };
-use num_integer::Integer;
+use num_integer::Integer as NumInteger;
 
-use crate::traits::{CryptoInteger, Words};
+use crate::traits::{Integer, Words};
 
 pub(crate) fn inner_product<'a, 'b, T, L, R>(lhs: L, rhs: R) -> T
 where
@@ -21,7 +21,7 @@ where
 }
 
 pub(crate) fn div_ceil(dividend: usize, divisor: usize) -> usize {
-    Integer::div_ceil(&dividend, &divisor)
+    NumInteger::div_ceil(&dividend, &divisor)
 }
 
 pub(crate) fn num_threads() -> usize {
@@ -107,9 +107,7 @@ where
 
     combined_row
 }
-pub(super) fn expand<N: CryptoInteger, M: CryptoInteger + for<'a> From<&'a N>>(
-    narrow_int: &N,
-) -> M {
+pub(super) fn expand<N: Integer, M: Integer + for<'a> From<&'a N>>(narrow_int: &N) -> M {
     assert!(
         N::W::num_words() <= M::W::num_words(),
         "Cannot squeeze a wide integer into a narrow integer."
@@ -126,8 +124,8 @@ mod test {
 
     use crate::{
         biginteger::Words,
-        crypto_int::CryptoInt,
-        traits::CryptoInteger,
+        crypto_int::Int,
+        traits::Integer,
         zip::utils::{expand, inner_product},
     };
 
@@ -141,8 +139,8 @@ mod test {
     #[test]
     fn test_expand_normal() {
         let input_words = [1u64, 2u64];
-        let input = CryptoInt::<2>::from_words(Words(input_words));
-        let expanded = expand::<CryptoInt<2>, CryptoInt<4>>(&input);
+        let input = Int::<2>::from_words(Words(input_words));
+        let expanded = expand::<Int<2>, Int<4>>(&input);
 
         let expected_words = [1u64, 2u64, 0u64, 0u64];
         assert_eq!(expanded.as_words(), expected_words);
@@ -151,8 +149,8 @@ mod test {
     #[test]
     fn test_expand_identity() {
         let input_words = Words([42u64, 99u64]);
-        let input = CryptoInt::<2>::from_words(input_words);
-        let expanded = expand::<CryptoInt<2>, CryptoInt<2>>(&input);
+        let input = Int::<2>::from_words(input_words);
+        let expanded = expand::<Int<2>, Int<2>>(&input);
 
         let expected_words = [42u64, 99u64];
         assert_eq!(expanded.as_words(), expected_words);
@@ -161,15 +159,15 @@ mod test {
     #[test]
     #[should_panic(expected = "Cannot squeeze a wide integer into a narrow integer.")]
     fn test_expand_invalid() {
-        let input = CryptoInt::<4>::from_words(Words([1, 2, 3, 4]));
+        let input = Int::<4>::from_words(Words([1, 2, 3, 4]));
         // N = 4, M = 2 → should panic
-        let _ = expand::<CryptoInt<4>, CryptoInt<2>>(&input);
+        let _ = expand::<Int<4>, Int<2>>(&input);
     }
 
     #[test]
     fn test_expand_zero_padding() {
-        let input = CryptoInt::<1>::from_words(Words([123]));
-        let expanded = expand::<CryptoInt<1>, CryptoInt<3>>(&input);
+        let input = Int::<1>::from_words(Words([123]));
+        let expanded = expand::<Int<1>, Int<3>>(&input);
 
         let expected_words = [123u64, 0u64, 0u64];
         assert_eq!(expanded.as_words(), expected_words);
@@ -177,8 +175,8 @@ mod test {
 
     #[test]
     fn test_expand_all_zeros() {
-        let input = CryptoInt::<2>::from_words(Words([0u64, 0u64]));
-        let expanded = expand::<CryptoInt<2>, CryptoInt<4>>(&input);
+        let input = Int::<2>::from_words(Words([0u64, 0u64]));
+        let expanded = expand::<Int<2>, Int<4>>(&input);
 
         let expected_words = [0u64, 0u64, 0u64, 0u64];
         assert_eq!(expanded.as_words(), expected_words);
@@ -186,27 +184,27 @@ mod test {
     #[test]
     fn test_expand_negative_number_identity() {
         // Example negative number in two's complement for 2 words
-        let negative_val = CryptoInt::<2>::from_words(Words([!0u64, !0u64])); // -1
-        let expanded = expand::<CryptoInt<2>, CryptoInt<2>>(&negative_val);
+        let negative_val = Int::<2>::from_words(Words([!0u64, !0u64])); // -1
+        let expanded = expand::<Int<2>, Int<2>>(&negative_val);
 
-        assert_eq!(expanded, CryptoInt::<2>::ZERO - &CryptoInt::<2>::ONE);
+        assert_eq!(expanded, Int::<2>::ZERO - &Int::<2>::ONE);
     }
 
     #[test]
     fn test_expand_negative_number_wider() {
         let mut rg = ark_std::test_rng();
 
-        let mut positive_val = CryptoInt::<2>::random(&mut rg);
-        if positive_val < CryptoInt::ZERO {
-            positive_val = CryptoInt::<2>::ZERO - &positive_val;
+        let mut positive_val = Int::<2>::random(&mut rg);
+        if positive_val < Int::ZERO {
+            positive_val = Int::<2>::ZERO - &positive_val;
         }
 
-        let expanded_positive = expand::<CryptoInt<2>, CryptoInt<4>>(&positive_val);
+        let expanded_positive = expand::<Int<2>, Int<4>>(&positive_val);
 
-        let negative_val = CryptoInt::<2>::ZERO - &positive_val;
-        let expanded_negative = expand::<CryptoInt<2>, CryptoInt<4>>(&negative_val);
+        let negative_val = Int::<2>::ZERO - &positive_val;
+        let expanded_negative = expand::<Int<2>, Int<4>>(&negative_val);
 
-        let expected_negative = CryptoInt::<4>::ZERO - &expanded_positive;
+        let expected_negative = Int::<4>::ZERO - &expanded_positive;
 
         assert_eq!(expanded_negative, expected_negative);
     }


### PR DESCRIPTION
Rename types and traits for simpler use and API:
- CryptoInt to Int
- CryptoUint to Uint
- CryptoInteger to Integer
- CryptoUinteger to Uinteger
- Integer to BigInteger
- Rename associated types to reflect these changes