### PR TITLE
Refactor Int conversion methods for consistency and clarity

### DIFF
--- a/src/biginteger/mod.rs
+++ b/src/biginteger/mod.rs
@@ -830,7 +830,7 @@ impl<const M: usize, const N: usize> From<&BigInt<N>> for Int<M> {
         let mut result = [0u64; M];
         result[..min_width].copy_from_slice(&words[..min_width]);
 
-        Int::from_words(Words(result))
+        Int::from(result)
     }
 }
 
@@ -1139,6 +1139,8 @@ impl<const N: usize> Default for Words<N> {
 }
 
 impl<const N: usize> crate::traits::Words for Words<N> {
+    type Word = u64;
+
     fn num_words() -> usize {
         N
     }

--- a/src/crypto_int/int.rs
+++ b/src/crypto_int/int.rs
@@ -122,6 +122,13 @@ impl<'a, const N: usize> Sub<&'a Self> for Int<N> {
     }
 }
 
+impl<const N: usize> From<[u64; N]> for Int<N> {
+    #[inline]
+    fn from(value: [u64; N]) -> Self {
+        Self(CryptoInt::from_words(value))
+    }
+}
+
 impl<const N: usize> From<i64> for Int<N> {
     #[inline]
     fn from(value: i64) -> Self {

--- a/src/field/conversion.rs
+++ b/src/field/conversion.rs
@@ -6,7 +6,8 @@ use crate::{
     field::{RandomField, RandomField::Raw},
     field_config::ConfigRef,
     traits::{
-        BigInteger, Config, ConfigReference, Field, FieldMap, FromBytes, Integer, Uinteger, Words,
+        BigInteger, Config, ConfigReference, Field, FieldMap, FromBytes, Integer,
+        PrimitiveConversion, Uinteger, Words,
     },
 };
 
@@ -85,10 +86,11 @@ macro_rules! impl_field_map_for_int {
                 let value = self.abs_diff(0);
                 let mut words = F::W::default();
 
-                words[0] = value as u64;
+                words[0] = PrimitiveConversion::from_primitive(value);
 
                 if (ark_std::mem::size_of::<$t>() + 7) / 8 > 1 && F::W::num_words() > 1 {
-                    words[1] = ((value as u128) >> 64) as u64;
+                    words[1] =
+                        PrimitiveConversion::from_primitive(u128::from_primitive(value) >> 64);
                 }
                 let mut value = F::U::from_words(words).as_int();
                 let modulus = F::I::from_words(config.modulus().to_words());

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,4 +2,7 @@ pub(crate) mod conversion;
 pub(crate) mod types;
 
 pub use conversion::{FieldMap, FromBytes};
-pub use types::{BigInteger, Config, ConfigReference, Field, Integer, Uinteger, Words};
+pub use types::{
+    BigInteger, Config, ConfigReference, Field, Integer, PrimitiveConversion, PrimitiveConversions,
+    Uinteger, Words,
+};

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -2,7 +2,9 @@ use ark_std::vec::Vec;
 use sha3::{Digest, Keccak256};
 
 use crate::{
-    traits::{BigInteger, Config, ConfigReference, Field, FieldMap, Integer, Words},
+    traits::{
+        BigInteger, Config, ConfigReference, Field, FieldMap, Integer, PrimitiveConversion, Words,
+    },
     zip::pcs::structs::ZipTranscript,
 };
 
@@ -128,7 +130,7 @@ impl KeccakTranscript {
             self.hasher.update([0x12]);
             self.hasher.update(challenge);
             self.hasher.update([0x34]);
-            words[i] = u64::from_le_bytes(challenge);
+            words[i] = PrimitiveConversion::from_primitive(u64::from_le_bytes(challenge));
         }
 
         I::from_words(words)

--- a/src/zip/utils.rs
+++ b/src/zip/utils.rs
@@ -123,7 +123,6 @@ mod test {
     use num_traits::{ConstOne, ConstZero};
 
     use crate::{
-        biginteger::Words,
         crypto_int::Int,
         traits::Integer,
         zip::utils::{expand, inner_product},
@@ -139,7 +138,7 @@ mod test {
     #[test]
     fn test_expand_normal() {
         let input_words = [1u64, 2u64];
-        let input = Int::<2>::from_words(Words(input_words));
+        let input = Int::<2>::from(input_words);
         let expanded = expand::<Int<2>, Int<4>>(&input);
 
         let expected_words = [1u64, 2u64, 0u64, 0u64];
@@ -148,8 +147,8 @@ mod test {
 
     #[test]
     fn test_expand_identity() {
-        let input_words = Words([42u64, 99u64]);
-        let input = Int::<2>::from_words(input_words);
+        let input_words = [42u64, 99u64];
+        let input = Int::<2>::from(input_words);
         let expanded = expand::<Int<2>, Int<2>>(&input);
 
         let expected_words = [42u64, 99u64];
@@ -159,14 +158,14 @@ mod test {
     #[test]
     #[should_panic(expected = "Cannot squeeze a wide integer into a narrow integer.")]
     fn test_expand_invalid() {
-        let input = Int::<4>::from_words(Words([1, 2, 3, 4]));
+        let input = Int::<4>::from([1, 2, 3, 4]);
         // N = 4, M = 2 → should panic
         let _ = expand::<Int<4>, Int<2>>(&input);
     }
 
     #[test]
     fn test_expand_zero_padding() {
-        let input = Int::<1>::from_words(Words([123]));
+        let input = Int::<1>::from([123]);
         let expanded = expand::<Int<1>, Int<3>>(&input);
 
         let expected_words = [123u64, 0u64, 0u64];
@@ -175,7 +174,7 @@ mod test {
 
     #[test]
     fn test_expand_all_zeros() {
-        let input = Int::<2>::from_words(Words([0u64, 0u64]));
+        let input = Int::<2>::from([0u64, 0u64]);
         let expanded = expand::<Int<2>, Int<4>>(&input);
 
         let expected_words = [0u64, 0u64, 0u64, 0u64];
@@ -184,7 +183,7 @@ mod test {
     #[test]
     fn test_expand_negative_number_identity() {
         // Example negative number in two's complement for 2 words
-        let negative_val = Int::<2>::from_words(Words([!0u64, !0u64])); // -1
+        let negative_val = Int::<2>::from([!0u64, !0u64]); // -1
         let expanded = expand::<Int<2>, Int<2>>(&negative_val);
 
         assert_eq!(expanded, Int::<2>::ZERO - &Int::<2>::ONE);


### PR DESCRIPTION
- Introduce PrimitiveConversion trait for more generic conversion from primitive types
- Some types that might be used for calculations (like num_bigint::Int or num_bigint::Uint) may use u32 instead of u64.
- Implementing integers optimized for 64-bit platforms might impact performance on 32-bit platforms